### PR TITLE
Fix netType usage in NewLibWallet, add WalletOpened function

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -601,15 +601,6 @@ func (lw *LibWallet) DropSpvConnection() {
 	}
 }
 
-func done(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	default:
-		return false
-	}
-}
-
 func (lw *LibWallet) OpenWallet(pubPass []byte) error {
 
 	w, err := lw.loader.OpenExistingWallet(pubPass)

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/decred/dcrd/addrmgr"
-	stake "github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
-	chainhash "github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/dcrutil"
@@ -37,7 +37,7 @@ import (
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/wallet/txauthor"
 	"github.com/decred/dcrwallet/wallet/txrules"
-	walletseed "github.com/decred/dcrwallet/walletseed"
+	"github.com/decred/dcrwallet/walletseed"
 	"github.com/decred/slog"
 )
 
@@ -612,6 +612,10 @@ func (lw *LibWallet) OpenWallet(pubPass []byte) error {
 	}
 	lw.wallet = w
 	return nil
+}
+
+func (lw *LibWallet) WalletOpened() bool {
+	return lw.wallet != nil
 }
 
 func (lw *LibWallet) RescanBlocks() error {

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -596,6 +596,9 @@ func (lw *LibWallet) DropSpvConnection() {
 	if lw.cancelSync != nil {
 		lw.cancelSync()
 	}
+	for _, syncResponse := range lw.syncResponses {
+		syncResponse.OnSynced(false)
+	}
 }
 
 func done(ctx context.Context) bool {

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -61,14 +61,16 @@ type LibWallet struct {
 	rescannning   bool
 }
 
-func NewLibWallet(homeDir string, dbDriver string, netType string) *LibWallet {
-
+func NewLibWallet(homeDir string, dbDriver string, netType string) (*LibWallet, error) {
 	var activeNet *netparams.Params
 
-	if netType == "mainnet" {
+	switch strings.ToLower(netType) {
+	case strings.ToLower(netparams.MainNetParams.Name):
 		activeNet = &netparams.MainNetParams
-	} else {
+	case strings.ToLower(netparams.TestNet3Params.Name):
 		activeNet = &netparams.TestNet3Params
+	default:
+		return nil, fmt.Errorf("Unsupported network type: %s", netType)
 	}
 
 	lw := &LibWallet{
@@ -76,9 +78,11 @@ func NewLibWallet(homeDir string, dbDriver string, netType string) *LibWallet {
 		dbDriver:  dbDriver,
 		activeNet: activeNet,
 	}
+
 	errors.Separator = ":: "
-	initLogRotator(filepath.Join(homeDir, "/logs/"+netType+"/dcrwallet.log"))
-	return lw
+	initLogRotator(filepath.Join(homeDir, "/logs/"+netType+"/dcrlibwallet.log"))
+
+	return lw, nil
 }
 
 func (lw *LibWallet) SetLogLevel(loglevel string) {

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -74,7 +74,7 @@ func NewLibWallet(homeDir string, dbDriver string, netType string) (*LibWallet, 
 	}
 
 	lw := &LibWallet{
-		dataDir:   filepath.Join(homeDir, netType),
+		dataDir:   filepath.Join(homeDir, activeNet.Name),
 		dbDriver:  dbDriver,
 		activeNet: activeNet,
 	}

--- a/log.go
+++ b/log.go
@@ -130,3 +130,7 @@ func setLogLevels(logLevel string) {
 		setLogLevel(subsystemID, logLevel)
 	}
 }
+
+func Log(m string){
+	log.Info(m)
+}

--- a/log.go
+++ b/log.go
@@ -131,6 +131,6 @@ func setLogLevels(logLevel string) {
 	}
 }
 
-func Log(m string){
+func Log(m string) {
 	log.Info(m)
 }


### PR DESCRIPTION
This checks if the netType string parameter passed to `NewLibWallet` is for a valid network type and returns an error if not.

This also ensures consistency when determining the wallet database directory using the network type param name.