### PR TITLE
Index transactions using storm db

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -944,7 +944,7 @@ func (lw *LibWallet) parseTxSummary(tx *wallet.TransactionSummary, blockHash *ch
 			AccountName:     lw.AccountName(int32(debit.PreviousAccount))}
 	}
 
-	var direction int32
+	var direction int32 = -1
 	if tx.Type == wallet.TransactionTypeRegular {
 		amountDifference := outputTotal - inputTotal
 		if amountDifference < 0 && (float64(tx.Fee) == math.Abs(float64(amountDifference))) {

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -636,15 +636,6 @@ func (lw *LibWallet) DropSpvConnection() {
 	}
 }
 
-func done(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	default:
-		return false
-	}
-}
-
 func (lw *LibWallet) OpenWallet(pubPass []byte) error {
 
 	w, err := lw.loader.OpenExistingWallet(pubPass)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/raedahgroup/dcrlibwallet
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 // indirect
+	github.com/asdine/storm v0.0.0-20190216191021-fe89819f6282
 	github.com/decred/dcrd/addrmgr v1.0.2
 	github.com/decred/dcrd/blockchain/stake v1.1.0
 	github.com/decred/dcrd/chaincfg v1.2.0
@@ -28,8 +29,6 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20180109070241-2de33835d102 // indirect
 	github.com/jrick/logrotate v1.0.0
 	github.com/pkg/errors v0.8.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
 )
 
 replace github.com/raedahgroup/dcrlibwallet => ./

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi81xWQA2QIVxjWkFHptGgC547vchpUbtFo=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+github.com/Sereal/Sereal v0.0.0-20181211220259-509a78ddbda3/go.mod h1:D0JMgToj/WdxCgd30Kc1UcA9E+WdZoJqeVOuYW7iTBM=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/asdine/storm v0.0.0-20190216191021-fe89819f6282 h1:DmSVc81daQAPvXwcCZi0W6A14sTCYQ1QI21C0E37KoY=
+github.com/asdine/storm v0.0.0-20190216191021-fe89819f6282/go.mod h1:cMLKpjHSP4q0P133fV15ojQgwWWB2IMv+hrFsmBF/wI=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
@@ -13,6 +16,7 @@ github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJ
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
 github.com/dchest/siphash v1.2.0 h1:YWOShuhvg0GqbQpMa60QlCGtEyf7O7HC1Jf0VjdQ60M=
@@ -177,6 +181,7 @@ github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -202,6 +207,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+go.etcd.io/bbolt v1.3.0 h1:oY10fI923Q5pVCVt1GBTZMn8LHo5M+RCInFpeMnV4QI=
+go.etcd.io/bbolt v1.3.0/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180808211826-de0752318171 h1:vYogbvSFj2YXcjQxFHu/rASSOt9sLytpCaSkiwQ135I=
 golang.org/x/crypto v0.0.0-20180808211826-de0752318171/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/log.go
+++ b/log.go
@@ -131,6 +131,6 @@ func setLogLevels(logLevel string) {
 	}
 }
 
-func Log(m string){
+func Log(m string) {
 	log.Info(m)
 }

--- a/log.go
+++ b/log.go
@@ -131,6 +131,6 @@ func setLogLevels(logLevel string) {
 	}
 }
 
-func Log(m string) {
+func Log(m string){
 	log.Info(m)
 }

--- a/response.go
+++ b/response.go
@@ -79,16 +79,6 @@ type TransactionCredit struct {
 	Address  string
 }
 
-type getTransactionsResponse struct {
-	Transactions  []Transaction
-	ErrorOccurred bool
-	ErrorMessage  string
-}
-
-type GetTransactionsResponse interface {
-	OnResult(json string)
-}
-
 type TransactionListener interface {
 	OnTransaction(transaction string)
 	OnTransactionConfirmed(hash string, height int32)

--- a/response.go
+++ b/response.go
@@ -51,18 +51,17 @@ Direction
 2: Transfered
 */
 type Transaction struct {
-	Hash        string
-	Raw         string
-	Transaction []byte
-	Fee         int64
-	Timestamp   int64
-	Type        string
-	Amount      int64
-	Status      string
-	Height      int32
-	Direction   int32
-	Debits      *[]TransactionDebit
-	Credits     *[]TransactionCredit
+	Hash      string `storm:"id,unique"`
+	Raw       string
+	Fee       int64
+	Timestamp int64
+	Type      string
+	Amount    int64
+	Status    string
+	Height    int32
+	Direction int32
+	Debits    *[]TransactionDebit
+	Credits   *[]TransactionCredit
 }
 
 type TransactionDebit struct {
@@ -132,6 +131,7 @@ type SpvSyncResponse interface {
 	OnFetchedHeaders(fetchedHeadersCount int32, lastHeaderTime int64, state string)
 	OnDiscoveredAddresses(state string)
 	OnRescan(rescannedThrough int32, state string)
+	OnIndexTransactions(totalIndex int32)
 	OnSynced(synced bool)
 	/*
 	* Handled Error Codes


### PR DESCRIPTION
Transactions are indexed after every sync for faster loading. It's useful in the case where transactions need to be queried in a specific order or based on the transaction attributes. It's faster because all transaction details are saved so it doesn't need to be fetched from the wallet because the wallet is slower when fetching transactions compared to using storm db.