### PR TITLE
Added added more query support to ReadFilter

### DIFF
--- a/txindex/filter.go
+++ b/txindex/filter.go
@@ -55,7 +55,7 @@ func (filter *ReadFilter) OrForDirections(txDirections ...txhelper.TransactionDi
 	return filter
 }
 
-func (filter *ReadFilter) createMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher ) q.Matcher {
+func (filter *ReadFilter) createMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher) q.Matcher {
 	if len(items) == 0 {
 		return filter.matcher
 	}
@@ -99,7 +99,7 @@ func (filter *ReadFilter) AndNotWithTxTypes(txTypes ...string) *ReadFilter {
 	return filter
 }
 
-func (filter *ReadFilter) createNotMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher ) q.Matcher {
+func (filter *ReadFilter) createNotMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher) q.Matcher {
 	if len(items) == 0 {
 		return filter.matcher
 	}

--- a/txindex/filter.go
+++ b/txindex/filter.go
@@ -1,22 +1,117 @@
 package txindex
 
-import "github.com/raedahgroup/dcrlibwallet/txhelper"
+import (
+	"github.com/asdine/storm/q"
+	"github.com/raedahgroup/dcrlibwallet/txhelper"
+)
 
 type ReadFilter struct {
-	typeFilter      []string
-	directionFilter []txhelper.TransactionDirection
+	matcher q.Matcher
 }
 
 func Filter() *ReadFilter {
 	return &ReadFilter{}
 }
 
-func (filter *ReadFilter) WithTxTypes(txTypes ...string) *ReadFilter {
-	filter.typeFilter = txTypes
+func (filter *ReadFilter) AndWithTxTypes(txTypes ...string) *ReadFilter {
+	var filterItems []interface{}
+	for _, txDirection := range txTypes {
+		filterItems = append(filterItems, txDirection)
+	}
+
+	filter.matcher = filter.createMatcher("Direction", filterItems, q.And)
 	return filter
 }
 
-func (filter *ReadFilter) ForDirections(txDirections ...txhelper.TransactionDirection) *ReadFilter {
-	filter.directionFilter = txDirections
+func (filter *ReadFilter) AndForDirections(txDirections ...txhelper.TransactionDirection) *ReadFilter {
+	var filterItems []interface{}
+	for _, txDirection := range txDirections {
+		filterItems = append(filterItems, txDirection)
+	}
+
+	filter.matcher = filter.createMatcher("Direction", filterItems, q.And)
+
 	return filter
+}
+
+func (filter *ReadFilter) OrWithTxTypes(txTypes ...string) *ReadFilter {
+	var filterItems []interface{}
+	for _, txDirection := range txTypes {
+		filterItems = append(filterItems, txDirection)
+	}
+
+	filter.matcher = filter.createMatcher("Direction", filterItems, q.Or)
+	return filter
+}
+
+func (filter *ReadFilter) OrForDirections(txDirections ...txhelper.TransactionDirection) *ReadFilter {
+	var filterItems []interface{}
+	for _, txDirection := range txDirections {
+		filterItems = append(filterItems, txDirection)
+	}
+
+	filter.matcher = filter.createMatcher("Direction", filterItems, q.Or)
+
+	return filter
+}
+
+func (filter *ReadFilter) createMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher ) q.Matcher {
+	if len(items) == 0 {
+		return filter.matcher
+	}
+	var matchers []q.Matcher
+	for _, item := range items {
+		matchers = append(matchers, q.StrictEq(fieldName, item))
+	}
+
+	if filter.matcher != nil {
+		matchers = append([]q.Matcher{filter.matcher}, matchers...)
+	}
+
+	var matcher q.Matcher
+	if len(matchers) > 1 {
+		matcher = joinFunc(matchers...)
+	} else {
+		matcher = matchers[0]
+	}
+	return matcher
+}
+
+func (filter *ReadFilter) AndNotForDirections(txDirections ...txhelper.TransactionDirection) *ReadFilter {
+	var filterItems []interface{}
+	for _, txDirection := range txDirections {
+		filterItems = append(filterItems, txDirection)
+	}
+
+	filter.matcher = filter.createNotMatcher("Direction", filterItems, q.And)
+
+	return filter
+}
+
+func (filter *ReadFilter) AndNotWithTxTypes(txTypes ...string) *ReadFilter {
+	var filterItems []interface{}
+	for _, txType := range txTypes {
+		filterItems = append(filterItems, txType)
+	}
+
+	filter.matcher = filter.createNotMatcher("Type", filterItems, q.And)
+
+	return filter
+}
+
+func (filter *ReadFilter) createNotMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher ) q.Matcher {
+	if len(items) == 0 {
+		return filter.matcher
+	}
+	var matchers []q.Matcher
+	for _, item := range items {
+		matchers = append(matchers, q.StrictEq(fieldName, item))
+	}
+
+	matcher := q.Not(matchers...)
+	if filter.matcher != nil {
+		matcher = q.And(filter.matcher, matcher)
+	}
+
+	return matcher
 }

--- a/txindex/filter.go
+++ b/txindex/filter.go
@@ -15,11 +15,11 @@ func Filter() *ReadFilter {
 
 func (filter *ReadFilter) AndWithTxTypes(txTypes ...string) *ReadFilter {
 	var filterItems []interface{}
-	for _, txDirection := range txTypes {
-		filterItems = append(filterItems, txDirection)
+	for _, txType := range txTypes {
+		filterItems = append(filterItems, txType)
 	}
 
-	filter.matcher = filter.createMatcher("Direction", filterItems, q.And)
+	filter.matcher = filter.createMatcher("Type", filterItems, q.And)
 	return filter
 }
 
@@ -30,17 +30,16 @@ func (filter *ReadFilter) AndForDirections(txDirections ...txhelper.TransactionD
 	}
 
 	filter.matcher = filter.createMatcher("Direction", filterItems, q.And)
-
 	return filter
 }
 
 func (filter *ReadFilter) OrWithTxTypes(txTypes ...string) *ReadFilter {
 	var filterItems []interface{}
-	for _, txDirection := range txTypes {
-		filterItems = append(filterItems, txDirection)
+	for _, txType := range txTypes {
+		filterItems = append(filterItems, txType)
 	}
 
-	filter.matcher = filter.createMatcher("Direction", filterItems, q.Or)
+	filter.matcher = filter.createMatcher("Type", filterItems, q.Or)
 	return filter
 }
 
@@ -55,12 +54,13 @@ func (filter *ReadFilter) OrForDirections(txDirections ...txhelper.TransactionDi
 	return filter
 }
 
-func (filter *ReadFilter) createMatcher(fieldName string, items []interface{}, joinFunc func(matchers ...q.Matcher) q.Matcher) q.Matcher {
-	if len(items) == 0 {
+func (filter *ReadFilter) createMatcher(fieldName string, fieldValues []interface{}, joinMatchers func(matchers ...q.Matcher) q.Matcher) q.Matcher {
+	if len(fieldValues) == 0 {
 		return filter.matcher
 	}
+
 	var matchers []q.Matcher
-	for _, item := range items {
+	for _, item := range fieldValues {
 		matchers = append(matchers, q.StrictEq(fieldName, item))
 	}
 
@@ -70,10 +70,11 @@ func (filter *ReadFilter) createMatcher(fieldName string, items []interface{}, j
 
 	var matcher q.Matcher
 	if len(matchers) > 1 {
-		matcher = joinFunc(matchers...)
+		matcher = joinMatchers(matchers...)
 	} else {
 		matcher = matchers[0]
 	}
+
 	return matcher
 }
 

--- a/txindex/read.go
+++ b/txindex/read.go
@@ -2,7 +2,6 @@ package txindex
 
 import (
 	"github.com/asdine/storm"
-	"github.com/asdine/storm/q"
 	"github.com/raedahgroup/dcrlibwallet/txhelper"
 )
 
@@ -31,17 +30,10 @@ func (db *DB) Read(offset, limit int32, filter *ReadFilter) (transactions []*txh
 }
 
 func (db *DB) createTxQuery(filter *ReadFilter) (query storm.Query) {
-	if filter == nil {
+	if filter == nil || filter.matcher == nil {
 		query = db.txDB.Select()
 	} else {
-		var filters []q.Matcher
-		for _, txType := range filter.typeFilter {
-			filters = append(filters, q.StrictEq("Type", txType))
-		}
-		for _, direction := range filter.directionFilter {
-			filters = append(filters, q.StrictEq("Direction", direction))
-		}
-		query = db.txDB.Select(filters...)
+		query = db.txDB.Select(filter.matcher)
 	}
 	return
 }


### PR DESCRIPTION
This PR added more filter definition functions to the `ReadFilter` struct and updated the `txindex.DB`'s `createTxQuery` function to use the new query mechanism.
The new functions are 
`AndWithTxTypes`
`AndForDirections`
`OrWithTxTypes`
`OrForDirections`
`AndNotForDirections` and
`AndNotWithTxTypes`
