### PR TITLE
always broadcast sync completed methods

### DIFF
--- a/syncprogressestimator/syncprogressestimator.go
+++ b/syncprogressestimator/syncprogressestimator.go
@@ -74,11 +74,6 @@ func (syncListener *SyncProgressEstimator) OnIndexTransactions(totalIndexed int3
 }
 
 func (syncListener *SyncProgressEstimator) OnSynced(synced bool) {
-	if !syncListener.syncing {
-		// ignore subsequent updates
-		return
-	}
-
 	syncListener.syncing = false
 
 	if synced {
@@ -89,11 +84,6 @@ func (syncListener *SyncProgressEstimator) OnSynced(synced bool) {
 }
 
 func (syncListener *SyncProgressEstimator) OnSyncEndedWithError(code int32, err error) {
-	if !syncListener.syncing {
-		// ignore subsequent updates
-		return
-	}
-
 	syncListener.syncing = false
 
 	syncError := fmt.Sprintf("Code: %d, Error: %s", code, err.Error())


### PR DESCRIPTION
If network connection is lost, number of connected peers drop to 0. When network is restored, the peers reconnect. This causes the sync callbacks to be re-invoked. Currently, the following sync callbacks are ignored if the wallet was already previously synced:
- `OnFetchedHeaders`
- `OnSynced` - triggered when sync ends
- `OnSyncEndedWithError`/`OnSyncError` - triggered when error occurs during sync

dcrandroid only ignores `OnFetchedHeaders` callback after a previously completed sync.

This PR allows `OnSynced` and `OnSyncEndedWithError`/`OnSyncError` callbacks to always be broadcasted, regardless of whether sync was completed previously.