### PR TITLE
account for sync inactivity periods when estimating eta

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -46,6 +46,14 @@ func (lw *LibWallet) AddEstimatedSyncProgressListener(syncProgressListener Estim
 	lw.AddSyncProgressListener(syncProgressEstimator)
 }
 
+func (lw *LibWallet) SyncInactiveForPeriod(totalInactiveSeconds int64) {
+	for _, syncProgressListener := range lw.syncProgressListeners {
+		if syncProgressEstimator, ok := syncProgressListener.(*syncprogressestimator.SyncProgressEstimator); ok {
+			syncProgressEstimator.DiscardPeriodsOfInactivity(totalInactiveSeconds)
+		}
+	}
+}
+
 func (lw *LibWallet) ResetSyncProgressListeners() {
 	for _, syncProgressListener := range lw.syncProgressListeners {
 		if syncProgressEstimator, ok := syncProgressListener.(*SyncProgressEstimator); ok {

--- a/sync.go
+++ b/sync.go
@@ -48,7 +48,7 @@ func (lw *LibWallet) AddEstimatedSyncProgressListener(syncProgressListener Estim
 
 func (lw *LibWallet) SyncInactiveForPeriod(totalInactiveSeconds int64) {
 	for _, syncProgressListener := range lw.syncProgressListeners {
-		if syncProgressEstimator, ok := syncProgressListener.(*syncprogressestimator.SyncProgressEstimator); ok {
+		if syncProgressEstimator, ok := syncProgressListener.(*SyncProgressEstimator); ok {
 			syncProgressEstimator.DiscardPeriodsOfInactivity(totalInactiveSeconds)
 		}
 	}


### PR DESCRIPTION
If the sync process gets interrupted for any reason, the sync estimation code currently does not discard the period of inactivity when calculating eta.

This PR adds a method for client apps to notify dcrlibwallet when sync process gets interrupted for some time to ensure that dcrlibwallet's estimated eta remains approximately accurate by accounting for lost time.

This PR also attempts to minimize bogus address discovery ETAs by setting a minimum estimate of 2 minutes for address discovery in situations where total headers fetch time is so small that address discovery estimate is negatively affected.