### PR TITLE
ignore subsequent sync callbacks after sync completes

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -16,14 +16,14 @@ import (
 )
 
 type syncData struct {
-	mu                    sync.Mutex
-	rpcClient             *chain.RPCClient
+	mu        sync.Mutex
+	rpcClient *chain.RPCClient
 
 	syncProgressListeners map[string]SyncProgressListener
 	showLogs              bool
 
-	syncing               bool
-	cancelSync            context.CancelFunc
+	syncing    bool
+	cancelSync context.CancelFunc
 
 	rescanning   bool
 	cancelRescan context.CancelFunc

--- a/sync.go
+++ b/sync.go
@@ -18,13 +18,17 @@ import (
 type syncData struct {
 	mu                    sync.Mutex
 	rpcClient             *chain.RPCClient
-	cancelSync            context.CancelFunc
+
 	syncProgressListeners map[string]SyncProgressListener
-	syncing               bool
 	showLogs              bool
+
+	syncing               bool
+	cancelSync            context.CancelFunc
 
 	rescanning   bool
 	cancelRescan context.CancelFunc
+
+	connectedPeers int32
 
 	*activeSyncData
 }
@@ -47,8 +51,6 @@ type activeSyncData struct {
 	addressDiscoveryCompleted chan bool
 
 	rescanStartTime int64
-
-	connectedPeers int32
 
 	totalInactiveSeconds int64
 }
@@ -118,7 +120,7 @@ func (lw *LibWallet) SyncInactiveForPeriod(totalInactiveSeconds int64) {
 	}
 
 	lw.syncData.totalInactiveSeconds += totalInactiveSeconds
-	if lw.activeSyncData.connectedPeers == 0 {
+	if lw.syncData.connectedPeers == 0 {
 		// assume it would take another 60 seconds to reconnect to peers
 		lw.syncData.totalInactiveSeconds += 60
 	}


### PR DESCRIPTION
This resolves 2 crash errors gotten from running dcrios with dcrlibwallet/master:

- attempting to access nil `lw.activeSyncData`)
`lw.activeSyncData` is nil if sync is not currently active, either because it was never started with `lw.spvSync/rpcSync` or because sync was either canceled or sync ended (with or without error).
<img width="1392" alt="Screenshot 2019-05-30 at 3 05 43 AM" src="https://user-images.githubusercontent.com/18400051/58603677-83825d00-8289-11e9-9ca7-6f53cdc297b6.png">

- attempting to update connected peer count after sync ends
<img width="1392" alt="Screenshot 2019-05-30 at 3 32 40 AM" src="https://user-images.githubusercontent.com/18400051/58604689-3607ef00-828d-11e9-9079-327012836e43.png">

