### PR TITLE
export max amount constant, check amount values for new txs

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -30,7 +30,7 @@ const (
 	DiscoveryPercentage = 0.8
 
 	MaxAmountAtom = dcrutil.MaxAmount
-	MaxAmountDcr = dcrutil.MaxAmount / dcrutil.AtomsPerCoin
+	MaxAmountDcr  = dcrutil.MaxAmount / dcrutil.AtomsPerCoin
 )
 
 func shutdownListener() {

--- a/utils.go
+++ b/utils.go
@@ -28,6 +28,9 @@ const (
 
 	// Use 80% of estimated total headers fetch time to estimate address discovery time
 	DiscoveryPercentage = 0.8
+
+	MaxAmountAtom = dcrutil.MaxAmount
+	MaxAmountDcr = dcrutil.MaxAmount / dcrutil.AtomsPerCoin
 )
 
 func shutdownListener() {


### PR DESCRIPTION
`lw.constructTransaction` stalls indefinitely when the minimum possible int64 value is passed as amount. This PR fixes that bug by checking amount values before constructing txs and also exporting the max dcr and atom amounts for use by client apps in in-app validation.