### PR TITLE
cleanup shutdown function

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/asdine/storm"
 	"github.com/decred/dcrd/dcrjson"
@@ -18,10 +16,6 @@ import (
 	"github.com/raedahgroup/dcrlibwallet/utils"
 	"go.etcd.io/bbolt"
 )
-
-var shutdownRequestChannel = make(chan struct{})
-var shutdownSignaled = make(chan struct{})
-var signals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 
 const (
 	logFileName = "dcrlibwallet.log"
@@ -46,14 +40,14 @@ func NewLibWallet(homeDir string, dbDriver string, netType string) (*LibWallet, 
 	}
 
 	walletDataDir := filepath.Join(homeDir, activeNet.Name)
-	return newLibWallet(walletDataDir, dbDriver, activeNet, true)
+	return newLibWallet(walletDataDir, dbDriver, activeNet)
 }
 
 func NewLibWalletWithDbPath(walletDataDir string, activeNet *netparams.Params) (*LibWallet, error) {
-	return newLibWallet(walletDataDir, "", activeNet, false)
+	return newLibWallet(walletDataDir, "", activeNet)
 }
 
-func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Params, listenForShutdown bool) (*LibWallet, error) {
+func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Params) (*LibWallet, error) {
 	errors.Separator = ":: "
 	initLogRotator(filepath.Join(walletDataDir, logFileName))
 
@@ -92,10 +86,6 @@ func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Par
 		walletLoader.SetDatabaseDriver(walletDbDriver)
 	}
 
-	if listenForShutdown {
-		go shutdownListener()
-	}
-
 	syncData := &syncData{
 		syncProgressListeners: make(map[string]SyncProgressListener),
 	}
@@ -112,19 +102,17 @@ func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Par
 	return lw, nil
 }
 
-func (lw *LibWallet) Shutdown(exit bool) {
-	log.Info("Shutting down mobile wallet")
+func (lw *LibWallet) Shutdown() {
+	log.Info("Shutting down dcrlibwallet")
+
+	// Trigger shuttingDown signal to cancel all contexts created with `contextWithShutdownCancel`.
+	shuttingDown <- true
 
 	if lw.rpcClient != nil {
 		lw.rpcClient.Stop()
 	}
 
 	lw.CancelSync(true)
-
-	if !IsChannelClosed(shutdownSignaled) {
-		log.Info("Channel not closed, closing")
-		close(shutdownSignaled)
-	}
 
 	if logRotator != nil {
 		log.Info("Shutting down log rotator")
@@ -148,34 +136,6 @@ func (lw *LibWallet) Shutdown(exit bool) {
 			log.Info("tx db closed successfully")
 		}
 	}
-
-	if exit {
-		os.Exit(0)
-	}
-}
-
-func (lw *LibWallet) DeleteWallet(privatePassphrase []byte) error {
-
-	defer func() {
-		for i := range privatePassphrase {
-			privatePassphrase[i] = 0
-		}
-	}()
-
-	wallet, loaded := lw.walletLoader.LoadedWallet()
-	if !loaded {
-		return errors.New(ErrWalletNotLoaded)
-	}
-
-	err := wallet.Unlock(privatePassphrase, nil)
-	if err != nil {
-		return translateError(err)
-	}
-	wallet.Lock()
-
-	lw.Shutdown(false)
-	log.Info("Deleting Wallet")
-	return os.RemoveAll(lw.walletDataDir)
 }
 
 func (lw *LibWallet) CallJSONRPC(method string, args string, address string, username string, password string, caCert string) (string, error) {

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -112,7 +112,7 @@ func (lw *LibWallet) Shutdown() {
 		lw.rpcClient.Stop()
 	}
 
-	lw.CancelSync(true)
+	lw.CancelSync()
 
 	if logRotator != nil {
 		log.Info("Shutting down log rotator")

--- a/sync.go
+++ b/sync.go
@@ -423,6 +423,7 @@ func (lw *LibWallet) IsScanning() bool {
 
 func (lw *LibWallet) GetBestBlock() int32 {
 	if lw.wallet == nil {
+		// This method is sometimes called after a wallet is deleted and causes crash.
 		log.Error("Attempting to read best block height without a loaded wallet.")
 		return 0
 	}
@@ -433,6 +434,7 @@ func (lw *LibWallet) GetBestBlock() int32 {
 
 func (lw *LibWallet) GetBestBlockTimeStamp() int64 {
 	if lw.wallet == nil {
+		// This method is sometimes called after a wallet is deleted and causes crash.
 		log.Error("Attempting to read best block timestamp without a loaded wallet.")
 		return 0
 	}

--- a/sync.go
+++ b/sync.go
@@ -30,8 +30,7 @@ type syncData struct {
 	rescanning   bool
 	cancelRescan context.CancelFunc
 
-	connectedPeers    int32
-	peersConnectionWG sync.WaitGroup
+	connectedPeers int32
 
 	*activeSyncData
 }
@@ -327,12 +326,6 @@ func (lw *LibWallet) CancelSync() {
 		lw.cancelSync() // will trigger context canceled in rpcSync or spvSync
 		lw.cancelSync = nil
 	}
-
-	// Peers sometimes continue to deliver sync updates even after the sync context has been canceled.
-	// Wait for all peers to disconnect to ensure that the sync operation is effectively canceled.
-	log.Info("Waiting to lose all peers")
-	lw.syncData.peersConnectionWG.Wait()
-	log.Info("All peers are gone")
 
 	loadedWallet, walletLoaded := lw.walletLoader.LoadedWallet()
 	if !walletLoaded {

--- a/sync.go
+++ b/sync.go
@@ -431,11 +431,21 @@ func (lw *LibWallet) IsScanning() bool {
 }
 
 func (lw *LibWallet) GetBestBlock() int32 {
+	if lw.wallet == nil {
+		log.Error("Attempting to read best block height without a loaded wallet.")
+		return 0
+	}
+
 	_, height := lw.wallet.MainChainTip()
 	return height
 }
 
 func (lw *LibWallet) GetBestBlockTimeStamp() int64 {
+	if lw.wallet == nil {
+		log.Error("Attempting to read best block timestamp without a loaded wallet.")
+		return 0
+	}
+
 	_, height := lw.wallet.MainChainTip()
 	identifier := wallet.NewBlockIdentifierFromHeight(height)
 	info, err := lw.wallet.BlockInfo(identifier)

--- a/sync.go
+++ b/sync.go
@@ -31,7 +31,6 @@ type syncData struct {
 	cancelRescan context.CancelFunc
 
 	connectedPeers int32
-	peersWG        sync.WaitGroup
 
 	*activeSyncData
 }
@@ -322,7 +321,7 @@ func (lw *LibWallet) connectToRpcClient(ctx context.Context, networkAddress stri
 	return
 }
 
-func (lw *LibWallet) CancelSync(losePeers bool) {
+func (lw *LibWallet) CancelSync() {
 	if lw.cancelSync != nil {
 		lw.cancelSync() // will trigger context canceled in rpcSync or spvSync
 		lw.cancelSync = nil
@@ -335,14 +334,6 @@ func (lw *LibWallet) CancelSync(losePeers bool) {
 
 	lw.walletLoader.SetNetworkBackend(nil)
 	loadedWallet.SetNetworkBackend(nil)
-
-	// It's important to wait to lose all peers when canceling sync
-	// if the wallet database would be closed after canceling sync.
-	if losePeers {
-		log.Info("Waiting to lose all peers")
-		lw.syncData.peersWG.Wait()
-		log.Info("All peers are gone")
-	}
 }
 
 func (lw *LibWallet) IsSyncing() bool {

--- a/sync.go
+++ b/sync.go
@@ -30,8 +30,8 @@ type syncData struct {
 	rescanning   bool
 	cancelRescan context.CancelFunc
 
-	connectedPeers int32
-	peersConnectionWG        sync.WaitGroup
+	connectedPeers    int32
+	peersConnectionWG sync.WaitGroup
 
 	*activeSyncData
 }

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -18,12 +18,10 @@ func (lw *LibWallet) spvSyncNotificationCallbacks() *spv.Notifications {
 	generalNotifications := lw.generalSyncNotificationCallbacks()
 	return &spv.Notifications{
 		PeerConnected: func(peerCount int32, addr string) {
-			lw.syncData.peersConnectionWG.Add(1)
 			lw.handlePeerCountUpdate(peerCount)
 		},
 		PeerDisconnected: func(peerCount int32, addr string) {
 			lw.handlePeerCountUpdate(peerCount)
-			lw.syncData.peersConnectionWG.Done()
 		},
 		Synced:                       generalNotifications.Synced,
 		FetchHeadersStarted:          generalNotifications.FetchHeadersStarted,

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -18,11 +18,9 @@ func (lw *LibWallet) spvSyncNotificationCallbacks() *spv.Notifications {
 	generalNotifications := lw.generalSyncNotificationCallbacks()
 	return &spv.Notifications{
 		PeerConnected: func(peerCount int32, addr string) {
-			lw.syncData.peersWG.Add(1)
 			lw.handlePeerCountUpdate(peerCount)
 		},
 		PeerDisconnected: func(peerCount int32, addr string) {
-			lw.syncData.peersWG.Done()
 			lw.handlePeerCountUpdate(peerCount)
 		},
 		Synced:                       generalNotifications.Synced,

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -18,10 +18,12 @@ func (lw *LibWallet) spvSyncNotificationCallbacks() *spv.Notifications {
 	generalNotifications := lw.generalSyncNotificationCallbacks()
 	return &spv.Notifications{
 		PeerConnected: func(peerCount int32, addr string) {
+			lw.syncData.peersConnectionWG.Add(1)
 			lw.handlePeerCountUpdate(peerCount)
 		},
 		PeerDisconnected: func(peerCount int32, addr string) {
 			lw.handlePeerCountUpdate(peerCount)
+			lw.syncData.peersConnectionWG.Done()
 		},
 		Synced:                       generalNotifications.Synced,
 		FetchHeadersStarted:          generalNotifications.FetchHeadersStarted,

--- a/wallet.go
+++ b/wallet.go
@@ -2,11 +2,11 @@ package dcrlibwallet
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/walletseed"
-	"os"
 )
 
 func (lw *LibWallet) WalletExists() (bool, error) {

--- a/wallet.go
+++ b/wallet.go
@@ -6,6 +6,7 @@ import (
 	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/walletseed"
+	"os"
 )
 
 func (lw *LibWallet) WalletExists() (bool, error) {
@@ -118,4 +119,28 @@ func (lw *LibWallet) ChangePublicPassphrase(oldPass []byte, newPass []byte) erro
 func (lw *LibWallet) CloseWallet() error {
 	err := lw.walletLoader.UnloadWallet()
 	return err
+}
+
+func (lw *LibWallet) DeleteWallet(privatePassphrase []byte) error {
+	defer func() {
+		for i := range privatePassphrase {
+			privatePassphrase[i] = 0
+		}
+	}()
+
+	wallet, loaded := lw.walletLoader.LoadedWallet()
+	if !loaded {
+		return errors.New(ErrWalletNotLoaded)
+	}
+
+	err := wallet.Unlock(privatePassphrase, nil)
+	if err != nil {
+		return translateError(err)
+	}
+	wallet.Lock()
+
+	lw.Shutdown()
+
+	log.Info("Deleting Wallet")
+	return os.RemoveAll(lw.walletDataDir)
 }


### PR DESCRIPTION
This code on master causes the `shutdownSignaled` signal to be broadcasted twice. This is especially noticable when `lw.ShutDown()` is called in the process of deleting a wallet. The result is that when a wallet is deleted and recreated, the second signal is processed and the newly created context for sync is canceled almost as soon as it is created.

```
if !IsChannelClosed(shutdownSignaled) {
	log.Info("Channel not closed, closing")
	close(shutdownSignaled)
}
```

This PR optimizes dcrlibwallet shutdown operations, removing redundant codes (interrupt signal listener included - allowing apps handle all shutdown process internally, calling `lw.Shutdown()` when necessary).

Also removes the need to wait for peer connections to be lost before deleting wallet.