### PR TITLE
wallet shutdown: wait for sync to completely cancel before closing wallet db

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -87,6 +87,7 @@ func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Par
 	}
 
 	syncData := &syncData{
+		syncCanceled:          make(chan bool),
 		syncProgressListeners: make(map[string]SyncProgressListener),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/decred/dcrd/chaincfg v1.3.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
-	github.com/decred/dcrd/dcrec v0.0.0-20190311054417-9a5161ce9e68
-	github.com/decred/dcrd/dcrjson v1.2.0
+	github.com/decred/dcrd/dcrec v0.0.0-20181212181811-1a370d38d671
+	github.com/decred/dcrd/dcrjson v1.1.0
 	github.com/decred/dcrd/dcrutil v1.2.0
 	github.com/decred/dcrd/hdkeychain v1.1.1
 	github.com/decred/dcrd/rpcclient v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -66,9 +66,8 @@ github.com/decred/dcrd/dcrec v0.0.0-20180721031028-5369a485acf6/go.mod h1:cRAH1S
 github.com/decred/dcrd/dcrec v0.0.0-20180801202239-0761de129164/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
 github.com/decred/dcrd/dcrec v0.0.0-20180809193022-9536f0c88fa8/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
 github.com/decred/dcrd/dcrec v0.0.0-20180816212643-20eda7ec9229/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
+github.com/decred/dcrd/dcrec v0.0.0-20181212181811-1a370d38d671 h1:7CaWvkh3YH6zUtM68d0HVxslhU2o4hChc22sDonRPbI=
 github.com/decred/dcrd/dcrec v0.0.0-20181212181811-1a370d38d671/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
-github.com/decred/dcrd/dcrec v0.0.0-20190311054417-9a5161ce9e68 h1:B1D7mNerPowhabwwGMB8ZzLiG8gtacAt+0CcIffpKDU=
-github.com/decred/dcrd/dcrec v0.0.0-20190311054417-9a5161ce9e68/go.mod h1:cRAH1SNk8Mi9hKBc/DHbeiWz/fyO8KWZR3H7okrIuOA=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721005212-59fe2b293f69/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20180721031028-5369a485acf6/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
 github.com/decred/dcrd/dcrec/edwards v0.0.0-20180809193022-9536f0c88fa8/go.mod h1:+ehP0Hk/mesyZXttxCtBbhPX23BMpZJ1pcVBqUfbmvU=
@@ -82,9 +81,8 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.1 h1:EFWVd1p0t0Y5tnsm/dJujgV0ORogRJ6
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1/go.mod h1:lhu4eZFSfTJWUnR3CFRcpD+Vta0KUAqnhTsTksHXgy0=
 github.com/decred/dcrd/dcrjson v1.0.0 h1:50DnA0XeV2JrQXoHh43TCKmH+kz2gHjZ1Mj/Pdk7Oz0=
 github.com/decred/dcrd/dcrjson v1.0.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
+github.com/decred/dcrd/dcrjson v1.1.0 h1:pFpbay3cWACkgloFxWjHBwlXWG2+S2QCJJzNxL40hwg=
 github.com/decred/dcrd/dcrjson v1.1.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
-github.com/decred/dcrd/dcrjson v1.2.0 h1:3BFFQHq3/YO/zae9WLxQkXsX6AXKx3+M8H3yk4oXZi0=
-github.com/decred/dcrd/dcrjson v1.2.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
 github.com/decred/dcrd/dcrutil v1.0.0/go.mod h1:CBpbItyMKkL/4i1qPJDsE/cdSYklsWFcTYgprRZh4yk=
 github.com/decred/dcrd/dcrutil v1.1.1 h1:zOkGiumN/JkobhAgpG/zfFgUoolGKVGYT5na1hbYUoE=
 github.com/decred/dcrd/dcrutil v1.1.1/go.mod h1:Jsttr0pEvzPAw+qay1kS1/PsbZYPyhluiNwwY6yBJS4=

--- a/sync.go
+++ b/sync.go
@@ -25,9 +25,10 @@ type syncData struct {
 	syncProgressListeners map[string]SyncProgressListener
 	showLogs              bool
 
-	synced     bool
-	syncing    bool
-	cancelSync context.CancelFunc
+	synced       bool
+	syncing      bool
+	cancelSync   context.CancelFunc
+	syncCanceled chan bool
 
 	rescanning bool
 
@@ -213,6 +214,7 @@ func (lw *LibWallet) SpvSync(peerAddresses string) error {
 		if err != nil {
 			if err == context.Canceled {
 				lw.notifySyncCanceled()
+				lw.syncCanceled <- true
 			} else if err == context.DeadlineExceeded {
 				lw.notifySyncError(ErrorCodeDeadlineExceeded, errors.E("SPV synchronization deadline exceeded: %v", err))
 			} else {
@@ -270,6 +272,7 @@ func (lw *LibWallet) RpcSync(networkAddress string, username string, password st
 		if err != nil {
 			if err == context.Canceled {
 				lw.notifySyncCanceled()
+				lw.syncCanceled <- true
 			} else if err == context.DeadlineExceeded {
 				lw.notifySyncError(ErrorCodeDeadlineExceeded, errors.E("RPC synchronization deadline exceeded: %v", err))
 			} else {
@@ -324,8 +327,16 @@ func (lw *LibWallet) connectToRpcClient(ctx context.Context, networkAddress stri
 
 func (lw *LibWallet) CancelSync() {
 	if lw.cancelSync != nil {
-		lw.cancelSync() // will trigger context canceled in rpcSync or spvSync
+		log.Info("Canceling sync. May take a while for sync to fully cancel.")
+
+		// Cancel the context used for syncer.Run in rpcSync() or spvSync().
+		lw.cancelSync()
 		lw.cancelSync = nil
+
+		// syncer.Run may not immediately return, following code blocks this function
+		// and waits for the syncer.Run to return `err == context.Canceled`.
+		<- lw.syncCanceled
+		log.Info("Sync fully canceled.")
 	}
 
 	loadedWallet, walletLoaded := lw.walletLoader.LoadedWallet()

--- a/sync.go
+++ b/sync.go
@@ -335,7 +335,7 @@ func (lw *LibWallet) CancelSync() {
 
 		// syncer.Run may not immediately return, following code blocks this function
 		// and waits for the syncer.Run to return `err == context.Canceled`.
-		<- lw.syncCanceled
+		<-lw.syncCanceled
 		log.Info("Sync fully canceled.")
 	}
 


### PR DESCRIPTION
Active sync is canceled by canceling the sync context using `lw.cancelSync()`. The sync process does not immediately halt however. This PR adds a `syncCanceled` channel that gets notified when the sync process eventually gets canceled (`syncer.Run` returns) and modifies the shutdown / sync cancellation process to wait for the `syncCanceled` channel to be triggered before proceeding.