### PR TITLE
Add RestartSpvSync and RestartRpcSync methods

### DIFF
--- a/syncnotification.go
+++ b/syncnotification.go
@@ -457,7 +457,7 @@ func (lw *LibWallet) notifySyncCanceled() {
 	lw.activeSyncData = nil // to be reintialized on next sync
 
 	for _, syncProgressListener := range lw.syncData.syncProgressListeners {
-		syncProgressListener.OnSyncCanceled()
+		syncProgressListener.OnSyncCanceled(lw.syncData.restartSyncRequested)
 	}
 }
 
@@ -473,7 +473,7 @@ func (lw *LibWallet) synced(synced bool) {
 			if synced {
 				syncProgressListener.OnSyncCompleted()
 			} else {
-				syncProgressListener.OnSyncCanceled()
+				syncProgressListener.OnSyncCanceled(false)
 			}
 		}
 	})

--- a/types.go
+++ b/types.go
@@ -124,7 +124,7 @@ type SyncProgressListener interface {
 	OnAddressDiscoveryProgress(addressDiscoveryProgress *AddressDiscoveryProgressReport)
 	OnHeadersRescanProgress(headersRescanProgress *HeadersRescanProgressReport)
 	OnSyncCompleted()
-	OnSyncCanceled()
+	OnSyncCanceled(willRestart bool)
 	OnSyncEndedWithError(err error)
 	Debug(debugInfo *DebugInfo)
 }


### PR DESCRIPTION
- Cancel any active sync and unset the wallet's network backend.
- Include `syncRestarting` flag when notifying callbacks of active sync cancellation. This to enable apps display an appropriate sync status message.
- Separate `RestartSpvSync` and `RestartRpcSync` methods to ensure that the relevant data needed to restart a sync operation is passed in.