### PR TITLE
shutdown: use one goroutine to listen for shutdown signal

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -100,6 +100,8 @@ func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Par
 		syncData:      syncData,
 	}
 
+	listenForShutdown()
+
 	return lw, nil
 }
 

--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -2,6 +2,7 @@ package dcrlibwallet
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -31,6 +32,9 @@ type LibWallet struct {
 	wallet        *wallet.Wallet
 	txDB          *storm.DB
 	*syncData
+
+	shuttingDown chan bool
+	cancelFuncs  []context.CancelFunc
 }
 
 func NewLibWallet(homeDir string, dbDriver string, netType string) (*LibWallet, error) {
@@ -100,7 +104,7 @@ func newLibWallet(walletDataDir, walletDbDriver string, activeNet *netparams.Par
 		syncData:      syncData,
 	}
 
-	listenForShutdown()
+	lw.listenForShutdown()
 
 	return lw, nil
 }
@@ -109,7 +113,7 @@ func (lw *LibWallet) Shutdown() {
 	log.Info("Shutting down dcrlibwallet")
 
 	// Trigger shuttingDown signal to cancel all contexts created with `contextWithShutdownCancel`.
-	shuttingDown <- true
+	lw.shuttingDown <- true
 
 	if lw.rpcClient != nil {
 		lw.rpcClient.Stop()

--- a/sync.go
+++ b/sync.go
@@ -207,7 +207,7 @@ func (lw *LibWallet) SpvSync(peerAddresses string) error {
 	loadedWallet.SetNetworkBackend(syncer)
 	lw.walletLoader.SetNetworkBackend(syncer)
 
-	ctx, cancel := contextWithShutdownCancel(context.Background())
+	ctx, cancel := lw.contextWithShutdownCancel(context.Background())
 	lw.cancelSync = cancel
 
 	// syncer.Run uses a wait group to block the thread until sync completes or an error occurs
@@ -253,7 +253,7 @@ func (lw *LibWallet) RpcSync(networkAddress string, username string, password st
 		return errors.New(ErrSyncAlreadyInProgress)
 	}
 
-	ctx, cancel := contextWithShutdownCancel(context.Background())
+	ctx, cancel := lw.contextWithShutdownCancel(context.Background())
 	lw.cancelSync = cancel
 
 	chainClient, err := lw.connectToRpcClient(ctx, networkAddress, username, password, cert)
@@ -393,7 +393,7 @@ func (lw *LibWallet) RescanBlocks() error {
 		}()
 
 		lw.rescanning = true
-		ctx, _ := contextWithShutdownCancel(context.Background())
+		ctx, _ := lw.contextWithShutdownCancel(context.Background())
 
 		progress := make(chan wallet.RescanProgress, 1)
 		go lw.wallet.RescanProgressFromHeight(ctx, netBackend, 0, progress)

--- a/transactions.go
+++ b/transactions.go
@@ -52,7 +52,7 @@ const (
 )
 
 func (lw *LibWallet) IndexTransactions(beginHeight int32, endHeight int32, afterIndexing func()) error {
-	ctx, _ := contextWithShutdownCancel(context.Background())
+	ctx, _ := lw.contextWithShutdownCancel(context.Background())
 
 	var totalIndex int32
 	var txEndHeight uint32

--- a/txauthor.go
+++ b/txauthor.go
@@ -180,7 +180,7 @@ func (lw *LibWallet) PublishUnminedTransactions() error {
 	if err != nil {
 		return errors.New(ErrNotConnected)
 	}
-	ctx, _ := contextWithShutdownCancel(context.Background())
+	ctx, _ := lw.contextWithShutdownCancel(context.Background())
 	err = lw.wallet.PublishUnminedTransactions(ctx, netBackend)
 	return err
 }

--- a/utils.go
+++ b/utils.go
@@ -31,21 +31,21 @@ const (
 	MaxAmountDcr  = dcrutil.MaxAmount / dcrutil.AtomsPerCoin
 )
 
-var shuttingDown = make(chan bool)
-var cancelFuncs = make([]context.CancelFunc, 0)
+func (lw *LibWallet) listenForShutdown() {
 
-func listenForShutdown() {
+	lw.cancelFuncs = make([]context.CancelFunc, 0)
+	lw.shuttingDown = make(chan bool)
 	go func() {
-		<-shuttingDown
-		for _, cancel := range cancelFuncs {
+		<-lw.shuttingDown
+		for _, cancel := range lw.cancelFuncs {
 			cancel()
 		}
 	}()
 }
 
-func contextWithShutdownCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+func (lw *LibWallet) contextWithShutdownCancel(ctx context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(ctx)
-	cancelFuncs = append(cancelFuncs, cancel)
+	lw.cancelFuncs = append(lw.cancelFuncs, cancel)
 	return ctx, cancel
 }
 

--- a/utils.go
+++ b/utils.go
@@ -32,13 +32,20 @@ const (
 )
 
 var shuttingDown = make(chan bool)
+var cancelFuncs = make([]context.CancelFunc, 0)
+
+func listenForShutdown() {
+	go func() {
+		<-shuttingDown
+		for _, cancel := range cancelFuncs {
+			cancel()
+		}
+	}()
+}
 
 func contextWithShutdownCancel(ctx context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-shuttingDown
-		cancel()
-	}()
+	cancelFuncs = append(cancelFuncs, cancel)
 	return ctx, cancel
 }
 


### PR DESCRIPTION
The previous implementation created a goroutine for each context created with shutdown cancel. This implementation uses one goroutine and stores the cancel functions in a slice which is then looped through and invoked once shutdown signal is received.
This change also fixes a bug that causes the code to be stuck when writing to the shutdown channel and there are zero subscribers on the channel.