### PR TITLE
abstract tx index db ops to txindex package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/dcrec v0.0.0-20181212181811-1a370d38d671
-	github.com/decred/dcrd/dcrjson v1.1.0
 	github.com/decred/dcrd/dcrutil v1.2.0
 	github.com/decred/dcrd/hdkeychain v1.1.1
 	github.com/decred/dcrd/rpcclient v1.1.0

--- a/sync.go
+++ b/sync.go
@@ -473,3 +473,7 @@ func (lw *LibWallet) GetBestBlockTimeStamp() int64 {
 	}
 	return info.Timestamp
 }
+
+func (lw *LibWallet) GetConnectedPeersCount() int32 {
+	return lw.connectedPeers
+}

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -468,7 +468,7 @@ func (lw *LibWallet) synced(synced bool) {
 
 	// begin indexing transactions after sync is completed,
 	// syncProgressListeners.OnSynced() will be invoked after transactions are indexed
-	lw.IndexTransactions(-1, -1, func() {
+	lw.IndexTransactions(func() {
 		for _, syncProgressListener := range lw.syncProgressListeners {
 			if synced {
 				syncProgressListener.OnSyncCompleted()

--- a/transactions.go
+++ b/transactions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrwallet/wallet"
+	"github.com/raedahgroup/dcrlibwallet/txhelper"
 	"github.com/raedahgroup/dcrlibwallet/txindex"
 )
 
@@ -34,16 +35,16 @@ const (
 	TxFilterStaking     = txindex.TxFilterStaking
 	TxFilterCoinBase    = txindex.TxFilterCoinBase
 
-	TxDirectionInvalid     = txindex.TxDirectionInvalid
-	TxDirectionSent        = txindex.TxDirectionSent
-	TxDirectionReceived    = txindex.TxDirectionReceived
-	TxDirectionTransferred = txindex.TxDirectionTransferred
+	TxDirectionInvalid     = txhelper.TxDirectionInvalid
+	TxDirectionSent        = txhelper.TxDirectionSent
+	TxDirectionReceived    = txhelper.TxDirectionReceived
+	TxDirectionTransferred = txhelper.TxDirectionTransferred
 
-	TxTypeRegular        = txindex.TxTypeRegular
-	TxTypeCoinBase       = txindex.TxTypeCoinBase
-	TxTypeTicketPurchase = txindex.TxTypeTicketPurchase
-	TxTypeVote           = txindex.TxTypeVote
-	TxTypeRevocation     = txindex.TxTypeRevocation
+	TxTypeRegular        = txhelper.TxTypeRegular
+	TxTypeCoinBase       = txhelper.TxTypeCoinBase
+	TxTypeTicketPurchase = txhelper.TxTypeTicketPurchase
+	TxTypeVote           = txhelper.TxTypeVote
+	TxTypeRevocation     = txhelper.TxTypeRevocation
 )
 
 func (lw *LibWallet) IndexTransactions(afterIndexing func()) error {

--- a/transactions.go
+++ b/transactions.go
@@ -68,7 +68,7 @@ func (lw *LibWallet) IndexTransactions(afterIndexing func()) error {
 				return false, err
 			}
 
-			err = lw.txDB.SaveOrUpdate(tx.Hash, tx)
+			err = lw.txDB.SaveOrUpdate(&Transaction{}, tx)
 			if err != nil {
 				log.Errorf("Index tx replace tx err :%v", err)
 				return false, err
@@ -134,7 +134,7 @@ func (lw *LibWallet) TransactionNotification(listener TransactionListener) {
 					return
 				}
 
-				err = lw.txDB.SaveOrUpdate(tempTransaction.Hash, tempTransaction)
+				err = lw.txDB.SaveOrUpdate(&Transaction{}, tempTransaction)
 				if err != nil {
 					log.Errorf("Tx ntfn replace tx err: %v", err)
 				}
@@ -158,7 +158,7 @@ func (lw *LibWallet) TransactionNotification(listener TransactionListener) {
 						return
 					}
 
-					err = lw.txDB.SaveOrUpdate(tempTransaction.Hash, tempTransaction)
+					err = lw.txDB.SaveOrUpdate(&Transaction{}, tempTransaction)
 					if err != nil {
 						log.Errorf("Incoming block replace tx error :%v", err)
 						return

--- a/transactions.go
+++ b/transactions.go
@@ -25,12 +25,6 @@ type TransactionListener interface {
 }
 
 const (
-	BucketTxInfo   = "TxIndexInfo"
-	KeyEndBlock    = "EndBlock"
-	MaxReOrgBlocks = 6
-)
-
-const (
 	// Export constants for use in mobile apps
 	// since gomobile excludes fields from sub packages.
 	TxFilterAll         = txindex.TxFilterAll

--- a/transactions.go
+++ b/transactions.go
@@ -30,25 +30,26 @@ const (
 	MaxReOrgBlocks = 6
 )
 
-// todo should reference txindex properties
 const (
-	TxFilterAll         int32 = 0
-	TxFilterSent        int32 = 1
-	TxFilterReceived    int32 = 2
-	TxFilterTransferred int32 = 3
-	TxFilterStaking     int32 = 4
-	TxFilterCoinBase    int32 = 5
+	// Export constants for use in mobile apps
+	// since gomobile excludes fields from sub packages.
+	TxFilterAll         = txindex.TxFilterAll
+	TxFilterSent        = txindex.TxFilterSent
+	TxFilterReceived    = txindex.TxFilterReceived
+	TxFilterTransferred = txindex.TxFilterTransferred
+	TxFilterStaking     = txindex.TxFilterStaking
+	TxFilterCoinBase    = txindex.TxFilterCoinBase
 
-	TxDirectionInvalid     int32 = -1
-	TxDirectionSent        int32 = 0
-	TxDirectionReceived    int32 = 1
-	TxDirectionTransferred int32 = 2
+	TxDirectionInvalid     = txindex.TxDirectionInvalid
+	TxDirectionSent        = txindex.TxDirectionSent
+	TxDirectionReceived    = txindex.TxDirectionReceived
+	TxDirectionTransferred = txindex.TxDirectionTransferred
 
-	TxTypeRegular        = "REGULAR"
-	TxTypeCoinBase       = "COINBASE"
-	TxTypeTicketPurchase = "TICKET_PURCHASE"
-	TxTypeVote           = "VOTE"
-	TxTypeRevocation     = "REVOCATION"
+	TxTypeRegular        = txindex.TxTypeRegular
+	TxTypeCoinBase       = txindex.TxTypeCoinBase
+	TxTypeTicketPurchase = txindex.TxTypeTicketPurchase
+	TxTypeVote           = txindex.TxTypeVote
+	TxTypeRevocation     = txindex.TxTypeRevocation
 )
 
 func (lw *LibWallet) IndexTransactions(afterIndexing func()) error {
@@ -232,7 +233,7 @@ func (lw *LibWallet) parseTxSummary(tx *wallet.TransactionSummary, blockHash *ch
 			AccountName:     lw.AccountName(int32(debit.PreviousAccount))}
 	}
 
-	var direction int32 = TxDirectionInvalid
+	var direction = TxDirectionInvalid
 	if tx.Type == wallet.TransactionTypeRegular {
 		amountDifference := outputTotal - inputTotal
 		if amountDifference < 0 && (float64(tx.Fee) == math.Abs(float64(amountDifference))) {

--- a/txhelper/types.go
+++ b/txhelper/types.go
@@ -1,5 +1,18 @@
 package txhelper
 
+const (
+	TxDirectionInvalid     int32 = -1
+	TxDirectionSent        int32 = 0
+	TxDirectionReceived    int32 = 1
+	TxDirectionTransferred int32 = 2
+
+	TxTypeRegular        = "REGULAR"
+	TxTypeCoinBase       = "COINBASE"
+	TxTypeTicketPurchase = "TICKET_PURCHASE"
+	TxTypeVote           = "VOTE"
+	TxTypeRevocation     = "REVOCATION"
+)
+
 type TransactionDestination struct {
 	Address string
 	Amount  float64

--- a/txindex/db.go
+++ b/txindex/db.go
@@ -1,0 +1,106 @@
+package txindex
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/asdine/storm"
+	"go.etcd.io/bbolt"
+)
+
+const (
+	DbName = "tx.db"
+
+	TxBucketName = "TxIndexInfo"
+	KeyDbVersion = "DbVersion"
+
+	// Necessary to force re-indexing if changes are made to the structure of data being stored.
+	// Increment this version number if db structure changes such that client apps need to re-index.
+	TxDbVersion uint32 = 1
+)
+
+type DB struct {
+	txDB  *storm.DB
+	Close func() error
+}
+
+// Initialize opens the existing storm db at `dbPath`
+// and checks the database version for compatibility.
+// If there is a version mismatch or the db does not exist at `dbPath`,
+// a new db is created and the current db version number saved to the db.
+func Initialize(dbPath string, data interface{}) (*DB, error) {
+	txDB, err := openOrCreateDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	txDB, err = ensureDatabaseVersion(txDB, dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// init database for saving/reading transaction objects
+	err = txDB.Init(data)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing tx database for wallet: %s", err.Error())
+	}
+
+	return &DB{
+		txDB,
+		txDB.Close,
+	}, nil
+}
+
+func openOrCreateDB(dbPath string) (*storm.DB, error) {
+	var isNewDbFile bool
+
+	// first check if db file exists at dbPath, if not we'll need to create it and set the db version
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			isNewDbFile = true
+		} else {
+			return nil, fmt.Errorf("error checking tx index database file: %s", err.Error())
+		}
+	}
+
+	txDB, err := storm.Open(dbPath)
+	if err != nil {
+		switch err {
+		case bolt.ErrTimeout:
+			// timeout error occurs if storm fails to acquire a lock on the database file
+			return nil, fmt.Errorf("tx index database is in use by another process")
+		default:
+			return nil, fmt.Errorf("error opening tx index database: %s", err.Error())
+		}
+	}
+
+	if isNewDbFile {
+		err = txDB.Set(TxBucketName, KeyDbVersion, TxDbVersion)
+		if err != nil {
+			os.RemoveAll(dbPath)
+			return nil, fmt.Errorf("error initializing tx index db: %s", err.Error())
+		}
+	}
+
+	return txDB, nil
+}
+
+// ensureDatabaseVersion checks the version of the existing db against `TxDbVersion`.
+// If there's a difference, the current tx index db file is deleted and a new one created.
+func ensureDatabaseVersion(txDB *storm.DB, dbPath string) (*storm.DB, error) {
+	var currentDbVersion uint32
+	err := txDB.Get(TxBucketName, KeyDbVersion, &currentDbVersion)
+	if err != nil && err != storm.ErrNotFound {
+		// ignore key not found errors as earlier db versions did not set a version number in the db.
+		return nil, fmt.Errorf("error checking tx index database version: %s", err.Error())
+	}
+
+	if currentDbVersion != TxDbVersion {
+		if err = os.RemoveAll(dbPath); err != nil {
+			return nil, fmt.Errorf("error deleting outdated tx index database: %s", err.Error())
+		}
+		return openOrCreateDB(dbPath)
+	}
+
+	return txDB, nil
+}

--- a/txindex/filter.go
+++ b/txindex/filter.go
@@ -1,0 +1,79 @@
+package txindex
+
+import (
+	"github.com/asdine/storm"
+	"github.com/asdine/storm/q"
+)
+
+const (
+	TxFilterAll         int32 = 0
+	TxFilterSent        int32 = 1
+	TxFilterReceived    int32 = 2
+	TxFilterTransferred int32 = 3
+	TxFilterStaking     int32 = 4
+	TxFilterCoinBase    int32 = 5
+
+	TxDirectionInvalid     int32 = -1
+	TxDirectionSent        int32 = 0
+	TxDirectionReceived    int32 = 1
+	TxDirectionTransferred int32 = 2
+
+	TxTypeRegular        = "REGULAR"
+	TxTypeCoinBase       = "COINBASE"
+	TxTypeTicketPurchase = "TICKET_PURCHASE"
+	TxTypeVote           = "VOTE"
+	TxTypeRevocation     = "REVOCATION"
+)
+
+func DetermineTxFilter(txType string, txDirection int32) int32 {
+	if txType == TxTypeCoinBase {
+		return TxFilterCoinBase
+	}
+	if txType != TxTypeRegular {
+		return TxFilterStaking
+	}
+
+	switch txDirection {
+	case TxDirectionSent:
+		return TxFilterSent
+	case TxDirectionReceived:
+		return TxFilterReceived
+	default:
+		return TxFilterTransferred
+	}
+}
+
+func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
+	switch txFilter {
+	case TxFilterSent:
+		query = db.txDB.Select(
+			q.Eq("Direction", TxDirectionSent),
+		)
+	case TxFilterReceived:
+		query = db.txDB.Select(
+			q.Eq("Direction", TxDirectionReceived),
+		)
+	case TxFilterTransferred:
+		query = db.txDB.Select(
+			q.Eq("Direction", TxDirectionTransferred),
+		)
+	case TxFilterStaking:
+		query = db.txDB.Select(
+			q.Not(
+				q.Eq("Type", TxTypeRegular),
+				q.Eq("Type", TxTypeCoinBase),
+			),
+		)
+	case TxFilterCoinBase:
+		query = db.txDB.Select(
+			q.Eq("Type", TxTypeCoinBase),
+		)
+	default:
+		query = db.txDB.Select(
+			q.True(),
+		)
+	}
+
+	query = query.OrderBy("Timestamp").Reverse()
+	return
+}

--- a/txindex/filter.go
+++ b/txindex/filter.go
@@ -3,6 +3,7 @@ package txindex
 import (
 	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
+	"github.com/raedahgroup/dcrlibwallet/txhelper"
 )
 
 const (
@@ -12,31 +13,20 @@ const (
 	TxFilterTransferred int32 = 3
 	TxFilterStaking     int32 = 4
 	TxFilterCoinBase    int32 = 5
-
-	TxDirectionInvalid     int32 = -1
-	TxDirectionSent        int32 = 0
-	TxDirectionReceived    int32 = 1
-	TxDirectionTransferred int32 = 2
-
-	TxTypeRegular        = "REGULAR"
-	TxTypeCoinBase       = "COINBASE"
-	TxTypeTicketPurchase = "TICKET_PURCHASE"
-	TxTypeVote           = "VOTE"
-	TxTypeRevocation     = "REVOCATION"
 )
 
 func DetermineTxFilter(txType string, txDirection int32) int32 {
-	if txType == TxTypeCoinBase {
+	if txType == txhelper.TxTypeCoinBase {
 		return TxFilterCoinBase
 	}
-	if txType != TxTypeRegular {
+	if txType != txhelper.TxTypeRegular {
 		return TxFilterStaking
 	}
 
 	switch txDirection {
-	case TxDirectionSent:
+	case txhelper.TxDirectionSent:
 		return TxFilterSent
-	case TxDirectionReceived:
+	case txhelper.TxDirectionReceived:
 		return TxFilterReceived
 	default:
 		return TxFilterTransferred
@@ -47,26 +37,26 @@ func (db *DB) prepareTxQuery(txFilter int32) (query storm.Query) {
 	switch txFilter {
 	case TxFilterSent:
 		query = db.txDB.Select(
-			q.Eq("Direction", TxDirectionSent),
+			q.Eq("Direction", txhelper.TxDirectionSent),
 		)
 	case TxFilterReceived:
 		query = db.txDB.Select(
-			q.Eq("Direction", TxDirectionReceived),
+			q.Eq("Direction", txhelper.TxDirectionReceived),
 		)
 	case TxFilterTransferred:
 		query = db.txDB.Select(
-			q.Eq("Direction", TxDirectionTransferred),
+			q.Eq("Direction", txhelper.TxDirectionTransferred),
 		)
 	case TxFilterStaking:
 		query = db.txDB.Select(
 			q.Not(
-				q.Eq("Type", TxTypeRegular),
-				q.Eq("Type", TxTypeCoinBase),
+				q.Eq("Type", txhelper.TxTypeRegular),
+				q.Eq("Type", txhelper.TxTypeCoinBase),
 			),
 		)
 	case TxFilterCoinBase:
 		query = db.txDB.Select(
-			q.Eq("Type", TxTypeCoinBase),
+			q.Eq("Type", txhelper.TxTypeCoinBase),
 		)
 	default:
 		query = db.txDB.Select(

--- a/txindex/read.go
+++ b/txindex/read.go
@@ -35,7 +35,7 @@ func (db *DB) Read(offset, limit, txFilter int32, transactions interface{}) erro
 		query = query.Limit(int(limit))
 	}
 
-	return query.Find(&transactions)
+	return query.Find(transactions)
 }
 
 // Count queries the db for transactions of the `txObj` type

--- a/txindex/read.go
+++ b/txindex/read.go
@@ -35,7 +35,11 @@ func (db *DB) Read(offset, limit, txFilter int32, transactions interface{}) erro
 		query = query.Limit(int(limit))
 	}
 
-	return query.Find(transactions)
+	err := query.Find(transactions)
+	if err != nil && err != storm.ErrNotFound {
+		return err
+	}
+	return nil
 }
 
 // Count queries the db for transactions of the `txObj` type

--- a/txindex/read.go
+++ b/txindex/read.go
@@ -1,0 +1,52 @@
+package txindex
+
+import (
+	"github.com/asdine/storm"
+)
+
+const MaxReOrgBlocks = 6
+
+// ReadIndexingStartBlock checks if the end block height was saved from last indexing operation.
+// If so, the end block height - MaxReOrgBlocks is returned.
+// Otherwise, 0 is returned to begin indexing from height 0.
+func (db *DB) ReadIndexingStartBlock() (int32, error) {
+	var startBlockHeight int32
+	err := db.txDB.Get(TxBucketName, KeyEndBlock, &startBlockHeight)
+	if err != nil && err != storm.ErrNotFound {
+		return 0, err
+	}
+
+	startBlockHeight -= MaxReOrgBlocks
+	if startBlockHeight < 0 {
+		startBlockHeight = 0
+	}
+	return startBlockHeight, nil
+}
+
+// Read queries the db for `limit` count transactions that match the specified `txFilter`
+// starting from the specified `offset`; and saves the transactions found to the received `transactions` object.
+// `transactions` should be a pointer to a slice of Transaction objects.
+func (db *DB) Read(offset, limit, txFilter int32, transactions interface{}) error {
+	query := db.prepareTxQuery(txFilter)
+	if offset > 0 {
+		query = query.Skip(int(offset))
+	}
+	if limit > 0 {
+		query = query.Limit(int(limit))
+	}
+
+	return query.Find(&transactions)
+}
+
+// Count queries the db for transactions of the `txObj` type
+// to return the number of records matching the specified `txFilter`.
+func (db *DB) Count(txFilter int32, txObj interface{}) (int, error) {
+	query := db.prepareTxQuery(txFilter)
+
+	count, err := query.Count(txObj)
+	if err != nil {
+		return -1, err
+	}
+
+	return count, nil
+}

--- a/txindex/save.go
+++ b/txindex/save.go
@@ -4,20 +4,21 @@ import (
 	"fmt"
 
 	"github.com/asdine/storm"
+	"reflect"
 )
 
 const KeyEndBlock = "EndBlock"
 
-func (db *DB) SaveOrUpdate(txHash string, tx interface{}) error {
-	var oldTx interface{}
-	err := db.txDB.One("Hash", txHash, &oldTx)
+func (db *DB) SaveOrUpdate(emptyTxPointer, tx interface{}) error {
+	txHash := reflect.ValueOf(tx).FieldByName("Hash").String()
+	err := db.txDB.One("Hash", txHash, emptyTxPointer)
 	if err != nil && err != storm.ErrNotFound {
 		return fmt.Errorf("error checking if tx was already indexed: %s", err.Error())
 	}
 
-	if oldTx != nil {
+	if emptyTxPointer != nil {
 		// delete old tx before saving new
-		err = db.txDB.DeleteStruct(&oldTx)
+		err = db.txDB.DeleteStruct(emptyTxPointer)
 		if err != nil {
 			return fmt.Errorf("error deleting previously indexed tx: %s", err.Error())
 		}

--- a/txindex/save.go
+++ b/txindex/save.go
@@ -10,13 +10,14 @@ import (
 const KeyEndBlock = "EndBlock"
 
 func (db *DB) SaveOrUpdate(emptyTxPointer, tx interface{}) error {
-	txHash := reflect.ValueOf(tx).FieldByName("Hash").String()
+	v := reflect.ValueOf(tx)
+	txHash := reflect.Indirect(v).FieldByName("Hash").String()
 	err := db.txDB.One("Hash", txHash, emptyTxPointer)
 	if err != nil && err != storm.ErrNotFound {
 		return fmt.Errorf("error checking if tx was already indexed: %s", err.Error())
 	}
 
-	if emptyTxPointer != nil {
+	if err == nil {
 		// delete old tx before saving new
 		err = db.txDB.DeleteStruct(emptyTxPointer)
 		if err != nil {

--- a/txindex/save.go
+++ b/txindex/save.go
@@ -1,0 +1,35 @@
+package txindex
+
+import (
+	"fmt"
+
+	"github.com/asdine/storm"
+)
+
+const KeyEndBlock = "EndBlock"
+
+func (db *DB) SaveOrUpdate(txHash string, tx interface{}) error {
+	var oldTx interface{}
+	err := db.txDB.One("Hash", txHash, &oldTx)
+	if err != nil && err != storm.ErrNotFound {
+		return fmt.Errorf("error checking if tx was already indexed: %s", err.Error())
+	}
+
+	if oldTx != nil {
+		// delete old tx before saving new
+		err = db.txDB.DeleteStruct(&oldTx)
+		if err != nil {
+			return fmt.Errorf("error deleting previously indexed tx: %s", err.Error())
+		}
+	}
+
+	return db.txDB.Save(tx)
+}
+
+func (db *DB) SaveLastIndexPoint(endBlockHeight int32) error {
+	err := db.txDB.Set(TxBucketName, KeyEndBlock, &endBlockHeight)
+	if err != nil {
+		return fmt.Errorf("error setting block height for last indexed tx: %s", err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
Create a `txindex` package to enable godcr perform tx index operations when using dcrwallet rpc rather than dcrlibwallet.

A subsequent PR will introduce other walletrpc helper functions to dcrlibwallet, but the changes here are primarily to permit code reusability between godcr and dcrlibwallet instead of writing tx indexing code on both projects.

A tiny change set included also is the added method to retrieve number of connected peers.

This is also a continuation of #6.