### PR TITLE
Update readme to include godcr's usage of dcrlibwallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/raedahgroup/dcrlibwallet.svg?branch=master)](https://travis-ci.org/raedahgroup/dcrlibwallet)
 
-A Decred wallet library written in golang for [dcrwallet](https://github.com/decred/dcrwallet)
+A standalone Decred wallet library written in golang for [dcrwallet](https://github.com/decred/dcrwallet), and used directly with [godcr](https://github.com/raedahgroup/godcr) for all wallet access and control functionality.
 
 ## Build Dependencies
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/raedahgroup/dcrlibwallet.svg?branch=master)](https://travis-ci.org/raedahgroup/dcrlibwallet)
 
-A standalone Decred wallet library written in golang for [dcrwallet](https://github.com/decred/dcrwallet), and used directly with [godcr](https://github.com/raedahgroup/godcr) for all wallet access and control functionality.
+A standalone Decred wallet library written in golang for [dcrwallet](https://github.com/decred/dcrwallet). Dcrlibwallet doesn't require gomobile to function rather it's used directly with [godcr](https://github.com/raedahgroup/godcr) for all wallet access and control functionality.
 
 ## Build Dependencies
 


### PR DESCRIPTION
The read-me file was edited to reflect godcr's dependence on the (dcrlibwallet) library for all wallet access and control functionality.