### PR TITLE
AccountIterator

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -49,10 +49,17 @@ func (lw *LibWallet) GetAccountsRaw(requiredConfirmations int32) (*Accounts, err
 	}, nil
 }
 
-func (accounts *Accounts) Next() *Account {
-	if accounts.Iter.CurrentIndex < len(accounts.Acc) {
-		account := accounts.Acc[accounts.Iter.CurrentIndex]
-		accounts.Iter.CurrentIndex++
+func (accounts *Accounts) GetAccountIterator() *AccountIterator {
+	return &AccountIterator{
+		CurrentIndex: 0,
+		Acc:          accounts.Acc,
+	}
+}
+
+func (iter *AccountIterator) Next() *Account {
+	if iter.CurrentIndex < len(iter.Acc) {
+		account := iter.Acc[iter.CurrentIndex]
+		iter.CurrentIndex++
 		return account
 	}
 	return nil

--- a/accounts.go
+++ b/accounts.go
@@ -49,6 +49,15 @@ func (lw *LibWallet) GetAccountsRaw(requiredConfirmations int32) (*Accounts, err
 	}, nil
 }
 
+func (accounts *Accounts) Next() *Account {
+	if accounts.Iter.CurrentIndex < len(accounts.Acc) {
+		account := accounts.Acc[accounts.Iter.CurrentIndex]
+		accounts.Iter.CurrentIndex++
+		return account
+	}
+	return nil
+}
+
 func (lw *LibWallet) GetAccountBalance(accountNumber int32, requiredConfirmations int32) (*Balance, error) {
 	balance, err := lw.wallet.CalculateAccountBalance(uint32(accountNumber), requiredConfirmations)
 	if err != nil {

--- a/accounts.go
+++ b/accounts.go
@@ -49,20 +49,46 @@ func (lw *LibWallet) GetAccountsRaw(requiredConfirmations int32) (*Accounts, err
 	}, nil
 }
 
-func (accounts *Accounts) GetAccountIterator() *AccountIterator {
-	return &AccountIterator{
-		CurrentIndex: 0,
-		Acc:          accounts.Acc,
+func (lw *LibWallet) AccountsIterator(requiredConfirmations int32) (*AccountsIterator, error) {
+	resp, err := lw.wallet.Accounts()
+	if err != nil {
+		return nil, err
 	}
+	accounts := make([]*Account, len(resp.Accounts))
+	for i, account := range resp.Accounts {
+		balance, err := lw.GetAccountBalance(int32(account.AccountNumber), requiredConfirmations)
+		if err != nil {
+			return nil, err
+		}
+
+		accounts[i] = &Account{
+			Number:           int32(account.AccountNumber),
+			Name:             account.AccountName,
+			TotalBalance:     int64(account.TotalBalance),
+			Balance:          balance,
+			ExternalKeyCount: int32(account.LastUsedExternalIndex + 20),
+			InternalKeyCount: int32(account.LastUsedInternalIndex + 20),
+			ImportedKeyCount: int32(account.ImportedKeyCount),
+		}
+	}
+
+	return &AccountsIterator{
+		currentIndex: 0,
+		accounts:     accounts,
+	}, nil
 }
 
-func (iter *AccountIterator) Next() *Account {
-	if iter.CurrentIndex < len(iter.Acc) {
-		account := iter.Acc[iter.CurrentIndex]
-		iter.CurrentIndex++
+func (accountsInterator *AccountsIterator) Next() *Account {
+	if accountsInterator.currentIndex < len(accountsInterator.accounts) {
+		account := accountsInterator.accounts[accountsInterator.currentIndex]
+		accountsInterator.currentIndex++
 		return account
 	}
 	return nil
+}
+
+func (accountsInterator *AccountsIterator) Reset() {
+	accountsInterator.currentIndex = 0
 }
 
 func (lw *LibWallet) GetAccountBalance(accountNumber int32, requiredConfirmations int32) (*Balance, error) {

--- a/go.mod
+++ b/go.mod
@@ -40,3 +40,5 @@ require (
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,3 @@ require (
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 )
-
-go 1.13

--- a/types.go
+++ b/types.go
@@ -42,6 +42,7 @@ type Account struct {
 
 type AccountIterator struct {
 	CurrentIndex int
+	Acc          []*Account
 }
 
 type Accounts struct {
@@ -52,7 +53,6 @@ type Accounts struct {
 	Acc                []*Account
 	CurrentBlockHash   []byte
 	CurrentBlockHeight int32
-	Iter               *AccountIterator
 }
 
 /** begin sync-related types */

--- a/types.go
+++ b/types.go
@@ -40,6 +40,10 @@ type Account struct {
 	ImportedKeyCount int32
 }
 
+type AccountIterator struct {
+	CurrentIndex int
+}
+
 type Accounts struct {
 	Count              int
 	ErrorMessage       string
@@ -48,6 +52,7 @@ type Accounts struct {
 	Acc                []*Account
 	CurrentBlockHash   []byte
 	CurrentBlockHeight int32
+	Iter               *AccountIterator
 }
 
 /** begin sync-related types */

--- a/types.go
+++ b/types.go
@@ -40,9 +40,9 @@ type Account struct {
 	ImportedKeyCount int32
 }
 
-type AccountIterator struct {
-	CurrentIndex int
-	Acc          []*Account
+type AccountsIterator struct {
+	currentIndex int
+	accounts     []*Account
 }
 
 type Accounts struct {


### PR DESCRIPTION
GoMobile does not export `Accounts.Acc` property. This PR resolves this with an iterator. 
This feature is used in PR https://github.com/raedahgroup/dcrios/pull/533