### PR TITLE
accounts: add legacy HD paths and a function to get HD path for account

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -2,8 +2,10 @@ package dcrlibwallet
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
+	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 )
 
@@ -188,4 +190,29 @@ func (wallet *Wallet) AccountNameRaw(accountNumber uint32) (string, error) {
 
 func (wallet *Wallet) AccountNumber(accountName string) (uint32, error) {
 	return wallet.internal.AccountNumber(wallet.shutdownContext(), accountName)
+}
+
+func (wallet *Wallet) HDPathForAccount(accountNumber int32) (string, error) {
+	cointype, err := wallet.internal.CoinType(wallet.shutdownContext())
+	if err != nil {
+		return "", translateError(err)
+	}
+
+	var hdPath string
+	isLegacyCoinType := cointype == wallet.chainParams.LegacyCoinType
+	if wallet.chainParams.Name == chaincfg.MainNetParams().Name {
+		if isLegacyCoinType {
+			hdPath = LegacyMainnetHDPath
+		} else {
+			hdPath = MainnetHDPath
+		}
+	} else {
+		if isLegacyCoinType {
+			hdPath = LegacyTestnetHDPath
+		} else {
+			hdPath = TestnetHDPath
+		}
+	}
+
+	return hdPath + strconv.Itoa(int(accountNumber)), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/raedahgroup/dcrlibwallet/spv v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.3.0 // indirect
 	go.etcd.io/bbolt v1.3.3
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/appengine v1.5.0 // indirect
 )
 

--- a/utils.go
+++ b/utils.go
@@ -32,8 +32,10 @@ const (
 	MaxAmountAtom = dcrutil.MaxAmount
 	MaxAmountDcr  = dcrutil.MaxAmount / dcrutil.AtomsPerCoin
 
-	TestnetHDPath = "m / 44' / 1' / "
-	MainnetHDPath = "m / 44' / 42' / "
+	TestnetHDPath       = "m / 44' / 1' / "
+	LegacyTestnetHDPath = "m / 44’ / 11’ / "
+	MainnetHDPath       = "m / 44' / 42' / "
+	LegacyMainnetHDPath = "m / 44’ / 20’ / "
 
 	DefaultRequiredConfirmations = 2
 )


### PR DESCRIPTION
This adds a helper function and it is used to get the HD path for the specified account. The function handles checking if the wallet is using a legacy coin-type or not, to determine what HD path belongs to it.