### PR TITLE
spv: use rescan point from lowest chain wallet

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -750,6 +750,11 @@ func (s *Syncer) lowestRescanPoint(ctx context.Context) (*chainhash.Hash, error)
 		}
 
 		if rescanPoint == nil {
+			hash, tip := w.MainChainTip(ctx)
+			if tip < rescanBlockHeight {
+				rescanChainHash = &hash
+				rescanBlockHeight = tip
+			}
 			continue
 		}
 

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -751,7 +751,7 @@ func (s *Syncer) lowestRescanPoint(ctx context.Context) (*chainhash.Hash, error)
 
 		if rescanPoint == nil {
 			hash, tip := w.MainChainTip(ctx)
-			if tip < rescanBlockHeight {
+			if tip < rescanBlockHeight || rescanBlockHeight == -1 {
 				rescanChainHash = &hash
 				rescanBlockHeight = tip
 			}


### PR DESCRIPTION
This will avoid a crash caused when the lowest chain wallet doesn't have the block returned from the lowest rescan point.