### PR TITLE
Add github actions and docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+    
+
+    - name: Build, run tests and vet
+      run:  |
+        go build
+        go test
+        go vet
+      env:
+        GO111MODULE: "on"
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 name: Docker Build
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,14 @@
+name: Docker Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      
+    - name: Build the Docker image
+      run: docker build -t dcrlibwallet .
+      
+    - name: Run the image
+      run: docker run dcrlibwallet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang 
+
+COPY . /root
+
+WORKDIR /root
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
+
+ENV GO111MODULE on
+
+CMD ["./run_tests.sh"]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# usage:
+# ./run_tests.sh
+#
+
+set -ex
+
+go test
+
+golangci-lint run --deadline=10m \
+      --disable-all \
+      --enable govet \
+      --enable staticcheck \
+      --enable gosimple \
+      --enable unconvert \
+      --enable ineffassign \
+      --enable structcheck \
+      --enable goimports \
+      --enable misspell \
+      --enable unparam \


### PR DESCRIPTION
Add a test  [script](https://github.com/raedahgroup/dcrlibwallet/pull/82/files#diff-c08082f308f76bbde9882b88503605be) which invokes `go test` and `golangci-lint`.

Add two github actions :
- `Go` : Runs `go build`, `go test` and `go vet`.
- `Docker` : Runs the test script.

Pipeline results can be viewed here: https://github.com/RogueElement/dcrlibwallet/actions.

Currently `Docker` fails because there are linting error in the package.