### PR TITLE
sync: close account discovery channel before canceling sync

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -53,7 +53,7 @@ type activeSyncData struct {
 	addressDiscoveryStartTime int64
 	totalDiscoveryTimeSpent   int64
 
-	addressDiscoveryCompleted chan bool
+	addressDiscoveryCompletedOrCanceled chan bool
 
 	rescanStartTime int64
 
@@ -251,6 +251,11 @@ func (mw *MultiWallet) RestartSpvSync() error {
 func (mw *MultiWallet) CancelSync() {
 	if mw.syncData.cancelSync != nil {
 		log.Info("Canceling sync. May take a while for sync to fully cancel.")
+
+		if mw.syncData.addressDiscoveryCompletedOrCanceled != nil {
+			close(mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled)
+			mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled = nil
+		}
 
 		// Cancel the context used for syncer.Run in spvSync().
 		mw.syncData.cancelSync()


### PR DESCRIPTION
Account discovery thread runs while sync is canceling and it eventually causes a crash. This pull request fixes it by canceling the account discovery thread before canceling sync.