### PR TITLE
Refactor syncData mutex to prevent potentially long locks

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -33,12 +33,11 @@ func (mw *MultiWallet) RescanBlocks(walletID int) error {
 			mw.syncData.mu.Unlock()
 		}()
 
+		ctx, cancel := wallet.shutdownContextWithCancel()
+
 		mw.syncData.mu.Lock()
 		mw.syncData.rescanning = true
-
-		ctx, cancel := wallet.shutdownContextWithCancel()
 		mw.syncData.cancelRescan = cancel
-
 		mw.syncData.mu.Unlock()
 
 		if mw.blocksRescanProgressListener != nil {

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -292,12 +292,15 @@ func (s *Syncer) highestChainTip(ctx context.Context) (chainhash.Hash, int32, *w
 // Run synchronizes the wallet, returning when synchronization fails or the
 // context is cancelled.
 func (s *Syncer) Run(ctx context.Context) error {
+	log.Infof("Syncing %d wallets", len(s.wallets))
+
 	tipHash, tipHeight, lowestChainWallet := s.lowestChainTip(ctx)
+	log.Infof("Headers synced through block %v height %d", &tipHash, tipHeight)
+
 	lowestRescanPoint, err := s.lowestRescanPoint(ctx)
 	if err != nil {
 		return err
 	}
-	log.Infof("Headers synced through block %v height %d", &tipHash, tipHeight)
 	if lowestRescanPoint != nil {
 		h, err := lowestChainWallet.BlockHeader(ctx, lowestRescanPoint)
 		if err != nil {
@@ -1292,8 +1295,6 @@ func (s *Syncer) fetchMissingCFilters(ctx context.Context, rp *p2p.RemotePeer) e
 }
 
 func (s *Syncer) startupSync(ctx context.Context, rp *p2p.RemotePeer) error {
-	log.Infof("Syncing %d wallets", len(s.wallets))
-
 	_, tipHeight, _ := s.highestChainTip(ctx)
 
 	// Disconnect from the peer if their advertised block height is

--- a/sync.go
+++ b/sync.go
@@ -314,7 +314,7 @@ func (mw *MultiWallet) CurrentSyncStage() int32 {
 	mw.syncData.mu.RLock()
 	defer mw.syncData.mu.RUnlock()
 
-	if mw.syncData != nil  && mw.syncData.syncing {
+	if mw.syncData != nil && mw.syncData.syncing {
 		return mw.syncData.syncStage
 	}
 	return InvalidSyncStage
@@ -324,7 +324,7 @@ func (mw *MultiWallet) GeneralSyncProgress() *GeneralSyncProgress {
 	mw.syncData.mu.RLock()
 	defer mw.syncData.mu.RUnlock()
 
-	if mw.syncData != nil  && mw.syncData.syncing {
+	if mw.syncData != nil && mw.syncData.syncing {
 		switch mw.syncData.syncStage {
 		case HeadersFetchSyncStage:
 			return mw.syncData.headersFetchProgress.GeneralSyncProgress

--- a/sync.go
+++ b/sync.go
@@ -262,11 +262,7 @@ func (mw *MultiWallet) RestartSpvSync() error {
 }
 
 func (mw *MultiWallet) CancelSync() {
-	mw.syncData.mu.RLock()
-	isSyncActive := mw.syncData.cancelSync != nil
-	mw.syncData.mu.RUnlock()
-
-	if isSyncActive {
+	if mw.IsSyncing() {
 		log.Info("Canceling sync. May take a while for sync to fully cancel.")
 
 		mw.syncData.mu.Lock()

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -41,9 +41,9 @@ func (mw *MultiWallet) handlePeerCountUpdate(peerCount int32) {
 
 	if mw.syncData.showLogs && mw.syncData.syncing {
 		if peerCount == 1 {
-			log.Infof("Connected to %d peer on %s.\n", peerCount, mw.chainParams.Name)
+			log.Infof("Connected to %d peer on %s.", peerCount, mw.chainParams.Name)
 		} else {
-			log.Infof("Connected to %d peers on %s.\n", peerCount, mw.chainParams.Name)
+			log.Infof("Connected to %d peers on %s.", peerCount, mw.chainParams.Name)
 		}
 	}
 }
@@ -71,7 +71,7 @@ func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
 	if mw.syncData.showLogs && mw.syncData.syncing {
 		blockInfo := mw.GetLowestBlock()
 		totalHeadersToFetch := mw.estimateBlockHeadersCountAfter(blockInfo.Timestamp)
-		log.Infof("Step 1 of 3 - fetching %d block headers.\n", totalHeadersToFetch)
+		log.Infof("Step 1 of 3 - fetching %d block headers.", totalHeadersToFetch)
 	}
 }
 
@@ -276,7 +276,7 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 				if mw.syncData.showLogs && mw.syncData.syncing {
 					// avoid logging same message multiple times
 					if totalProgressPercent != lastTotalPercent || totalTimeRemainingSeconds != lastTimeRemaining {
-						log.Infof("Syncing %d%%, %s remaining, discovering used addresses.\n",
+						log.Infof("Syncing %d%%, %s remaining, discovering used addresses.",
 							totalProgressPercent, CalculateTotalTimeRemaining(totalTimeRemainingSeconds))
 
 						lastTotalPercent = totalProgressPercent
@@ -363,7 +363,7 @@ func (mw *MultiWallet) rescanStarted(walletID int) {
 	mw.syncData.activeSyncData.headersRescanProgress.WalletID = walletID
 
 	if mw.syncData.showLogs && mw.syncData.syncing {
-		log.Info("Step 3 of 3 - Scanning block headers")
+		log.Info("Step 3 of 3 - Scanning block headers.")
 	}
 }
 
@@ -421,7 +421,7 @@ func (mw *MultiWallet) rescanProgress(walletID int, rescannedThrough int32) {
 	mw.publishDebugInfo(debugInfo)
 
 	if mw.syncData.showLogs && mw.syncData.syncing {
-		log.Infof("Syncing %d%%, %s remaining, scanning %d of %d block headers.\n",
+		log.Infof("Syncing %d%%, %s remaining, scanning %d of %d block headers.",
 			mw.syncData.activeSyncData.headersRescanProgress.TotalSyncProgress,
 			CalculateTotalTimeRemaining(mw.syncData.activeSyncData.headersRescanProgress.TotalTimeRemainingSeconds),
 			mw.syncData.activeSyncData.headersRescanProgress.CurrentRescanHeight,

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -33,13 +33,15 @@ func (mw *MultiWallet) spvSyncNotificationCallbacks() *spv.Notifications {
 
 func (mw *MultiWallet) handlePeerCountUpdate(peerCount int32) {
 	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
 	mw.syncData.connectedPeers = peerCount
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	shouldLog := mw.syncData.showLogs && mw.syncData.syncing
+	mw.syncData.mu.Unlock()
+
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.OnPeerConnectedOrDisconnected(peerCount)
 	}
 
-	if mw.syncData.showLogs && mw.syncData.syncing {
+	if shouldLog {
 		if peerCount == 1 {
 			log.Infof("Connected to %d peer on %s.", peerCount, mw.chainParams.Name)
 		} else {
@@ -51,11 +53,15 @@ func (mw *MultiWallet) handlePeerCountUpdate(peerCount int32) {
 // Fetch Headers Callbacks
 
 func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
-	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
-	if !mw.syncData.syncing || mw.syncData.beginFetchTimeStamp != -1 {
-		// ignore if sync is not in progress i.e. !mw.syncData.syncing
-		// or already started headers fetching i.e. mw.syncData.beginFetchTimeStamp != -1
+	mw.syncData.mu.RLock()
+	isSyncing := mw.syncData.syncing
+	headersFetchingStarted := mw.syncData.beginFetchTimeStamp != -1
+	showLogs := mw.syncData.showLogs
+	mw.syncData.mu.RUnlock()
+
+	if !isSyncing || headersFetchingStarted {
+		// This function gets called for each newly connected peer,
+		// so ignore if sync is not in progress or if headers fetching was already started.
 		return
 	}
 
@@ -63,51 +69,56 @@ func (mw *MultiWallet) fetchHeadersStarted(peerInitialHeight int32) {
 		wallet.waiting = true
 	}
 
+	lowestBlockHeight := mw.GetLowestBlock().Height
+
+	mw.syncData.mu.Lock()
 	mw.syncData.activeSyncData.syncStage = HeadersFetchSyncStage
 	mw.syncData.activeSyncData.beginFetchTimeStamp = time.Now().Unix()
-	mw.syncData.activeSyncData.startHeaderHeight = mw.GetLowestBlock().Height
-	mw.syncData.activeSyncData.totalFetchedHeadersCount = 0
+	mw.syncData.activeSyncData.startHeaderHeight = lowestBlockHeight
+	mw.syncData.mu.Unlock()
 
-	if mw.syncData.showLogs && mw.syncData.syncing {
-		blockInfo := mw.GetLowestBlock()
-		totalHeadersToFetch := mw.estimateBlockHeadersCountAfter(blockInfo.Timestamp)
-		log.Infof("Step 1 of 3 - fetching %d block headers.", totalHeadersToFetch)
+	if showLogs && isSyncing {
+		log.Infof("Step 1 of 3 - fetching %d block headers.", peerInitialHeight-lowestBlockHeight)
 	}
 }
 
-func (mw *MultiWallet) fetchHeadersProgress(fetchedHeadersCount int32, lastHeaderTime int64) {
-	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
+func (mw *MultiWallet) fetchHeadersProgress(lastFetchedHeaderHeight int32, lastFetchedHeaderTime int64) {
+	mw.syncData.mu.RLock()
+	isSyncing := mw.syncData.syncing
+	headersFetchingCompleted := mw.syncData.activeSyncData.headersFetchTimeSpent != -1
+	mw.syncData.mu.RUnlock()
 
-	if !mw.syncData.syncing || mw.syncData.activeSyncData.headersFetchTimeSpent != -1 {
-		// Ignore this call because this function gets called for each peer and
-		// we'd want to ignore those calls as far as the wallet is synced (i.e. !syncListener.syncing)
-		// or headers are completely fetched (i.e. syncListener.headersFetchTimeSpent != -1)
+	if !isSyncing || headersFetchingCompleted {
+		// This function gets called for each newly connected peer,
+		// so ignore this call if sync is not in progress or
+		// if the headers fetching phase was previously completed.
 		return
 	}
 
 	for _, wallet := range mw.wallets {
-		if wallet.GetBestBlock() <= fetchedHeadersCount {
-			wallet.waiting = false
+		if wallet.waiting {
+			wallet.waiting = wallet.GetBestBlock() > lastFetchedHeaderHeight
 		}
 	}
+
+	headersLeftToFetch := mw.estimateBlockHeadersCountAfter(lastFetchedHeaderTime)
+	totalHeadersToFetch := lastFetchedHeaderHeight + headersLeftToFetch
+	headersFetchProgress := float64(lastFetchedHeaderHeight) / float64(totalHeadersToFetch)
+	// todo: above equation is potentially flawed because `lastFetchedHeaderHeight`
+	// may not be the total number of headers fetched so far in THIS sync operation.
+	// it may include headers previously fetched.
+	// probably better to compare number of headers fetched so far in THIS sync operation
+	// against the estimated number of headers left to fetch in THIS sync operation
+	// in order to determine the headers fetch progress so far in THIS sync operation.
+
+	// lock the mutex before reading and writing to mw.syncData.*
+	mw.syncData.mu.Lock()
 
 	// If there was some period of inactivity,
 	// assume that this process started at some point in the future,
 	// thereby accounting for the total reported time of inactivity.
 	mw.syncData.activeSyncData.beginFetchTimeStamp += mw.syncData.activeSyncData.totalInactiveSeconds
 	mw.syncData.activeSyncData.totalInactiveSeconds = 0
-
-	mw.syncData.activeSyncData.totalFetchedHeadersCount = fetchedHeadersCount
-	headersLeftToFetch := mw.estimateBlockHeadersCountAfter(lastHeaderTime)
-	totalHeadersToFetch := mw.syncData.activeSyncData.totalFetchedHeadersCount + headersLeftToFetch
-	headersFetchProgress := float64(mw.syncData.activeSyncData.totalFetchedHeadersCount) / float64(totalHeadersToFetch)
-
-	// update headers fetching progress report
-	mw.syncData.activeSyncData.headersFetchProgress.TotalHeadersToFetch = totalHeadersToFetch
-	mw.syncData.activeSyncData.headersFetchProgress.CurrentHeaderTimestamp = lastHeaderTime
-	mw.syncData.activeSyncData.headersFetchProgress.FetchedHeadersCount = mw.syncData.activeSyncData.totalFetchedHeadersCount
-	mw.syncData.activeSyncData.headersFetchProgress.HeadersFetchProgress = roundUp(headersFetchProgress * 100.0)
 
 	timeTakenSoFar := time.Now().Unix() - mw.syncData.activeSyncData.beginFetchTimeStamp
 	if timeTakenSoFar < 1 {
@@ -119,6 +130,7 @@ func (mw *MultiWallet) fetchHeadersProgress(fetchedHeadersCount int32, lastHeade
 	// Account for this difference by multiplying the estimatedTotalHeadersFetchTime by an incrementing factor.
 	// The incrementing factor is inversely proportional to the headers fetch progress,
 	// ranging from 0.5 to 0 as headers fetching progress increases from 0 to 1.
+	// todo, the above noted (mal)calculation may explain this difference.
 	adjustmentFactor := 0.5 * (1 - headersFetchProgress)
 	estimatedTotalHeadersFetchTime += estimatedTotalHeadersFetchTime * adjustmentFactor
 
@@ -126,14 +138,25 @@ func (mw *MultiWallet) fetchHeadersProgress(fetchedHeadersCount int32, lastHeade
 	estimatedRescanTime := estimatedTotalHeadersFetchTime * RescanPercentage
 	estimatedTotalSyncTime := estimatedTotalHeadersFetchTime + estimatedDiscoveryTime + estimatedRescanTime
 
-	// update total progress percentage and total time remaining
 	totalSyncProgress := float64(timeTakenSoFar) / estimatedTotalSyncTime
 	totalTimeRemainingSeconds := int64(math.Round(estimatedTotalSyncTime)) - timeTakenSoFar
+
+	// update headers fetching progress report including total progress percentage and total time remaining
+	mw.syncData.activeSyncData.headersFetchProgress.TotalHeadersToFetch = totalHeadersToFetch
+	mw.syncData.activeSyncData.headersFetchProgress.CurrentHeaderHeight = lastFetchedHeaderHeight
+	mw.syncData.activeSyncData.headersFetchProgress.CurrentHeaderTimestamp = lastFetchedHeaderTime
+	mw.syncData.activeSyncData.headersFetchProgress.HeadersFetchProgress = roundUp(headersFetchProgress * 100.0)
 	mw.syncData.activeSyncData.headersFetchProgress.TotalSyncProgress = roundUp(totalSyncProgress * 100.0)
 	mw.syncData.activeSyncData.headersFetchProgress.TotalTimeRemainingSeconds = totalTimeRemainingSeconds
 
+	// unlock the mutex before issuing notification callbacks to prevent potential deadlock
+	// if any invoked callback takes a considerable amount of time to execute.
+	mw.syncData.mu.Unlock()
+
 	// notify progress listener of estimated progress report
 	mw.publishFetchHeadersProgress()
+
+	// todo: also log report if showLog == true
 
 	headersFetchTimeRemaining := estimatedTotalHeadersFetchTime - float64(timeTakenSoFar)
 	debugInfo := &DebugInfo{
@@ -146,7 +169,7 @@ func (mw *MultiWallet) fetchHeadersProgress(fetchedHeadersCount int32, lastHeade
 }
 
 func (mw *MultiWallet) publishFetchHeadersProgress() {
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.OnHeadersFetchProgress(&mw.syncData.headersFetchProgress)
 	}
 }
@@ -182,7 +205,6 @@ func (mw *MultiWallet) fetchHeadersFinished() {
 
 func (mw *MultiWallet) discoverAddressesStarted(walletID int) {
 	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
 
 	if !mw.syncData.syncing || mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled != nil {
 		// ignore if sync is not in progress i.e. !mw.syncData.syncing
@@ -193,16 +215,23 @@ func (mw *MultiWallet) discoverAddressesStarted(walletID int) {
 	mw.syncData.activeSyncData.syncStage = AddressDiscoverySyncStage
 	mw.syncData.activeSyncData.addressDiscoveryStartTime = time.Now().Unix()
 	mw.syncData.activeSyncData.addressDiscoveryProgress.WalletID = walletID
+
 	if mw.syncData.showLogs && mw.syncData.syncing {
 		log.Info("Step 2 of 3 - discovering used addresses.")
 	}
+
+	mw.syncData.mu.Unlock()
 
 	mw.updateAddressDiscoveryProgress()
 }
 
 func (mw *MultiWallet) updateAddressDiscoveryProgress() {
-	// these values will be used every second to calculate the total sync progress
+	mw.syncData.mu.Lock()
+	mw.syncData.addressDiscoveryCompletedOrCanceled = make(chan bool)
 	totalHeadersFetchTime := float64(mw.syncData.headersFetchTimeSpent)
+	mw.syncData.mu.Unlock()
+
+	// these values will be used every second to calculate the total sync progress
 	estimatedDiscoveryTime := totalHeadersFetchTime * DiscoveryPercentage
 	estimatedRescanTime := totalHeadersFetchTime * RescanPercentage
 
@@ -214,30 +243,22 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 	var lastTimeRemaining int64
 	var lastTotalPercent int32 = -1
 
-	mw.syncData.addressDiscoveryCompletedOrCanceled = make(chan bool)
-
 	go func() {
 		for {
-
-			mw.syncData.mu.Lock()
 			// If there was some period of inactivity,
 			// assume that this process started at some point in the future,
 			// thereby accounting for the total reported time of inactivity.
+			mw.syncData.mu.Lock()
 			mw.syncData.addressDiscoveryStartTime += mw.syncData.totalInactiveSeconds
 			mw.syncData.totalInactiveSeconds = 0
+			addressDiscoveryStartTime := mw.syncData.addressDiscoveryStartTime
+			showLogs := mw.syncData.showLogs
 			mw.syncData.mu.Unlock()
 
 			select {
 			case <-everySecondTickerChannel:
-				mw.syncData.mu.Lock()
-
-				if mw.syncData.activeSyncData == nil {
-					mw.syncData.mu.Unlock()
-					return
-				}
-
 				// calculate address discovery progress
-				elapsedDiscoveryTime := float64(time.Now().Unix() - mw.syncData.addressDiscoveryStartTime)
+				elapsedDiscoveryTime := float64(time.Now().Unix() - addressDiscoveryStartTime)
 				discoveryProgress := (elapsedDiscoveryTime / estimatedDiscoveryTime) * 100
 
 				var totalSyncTime float64
@@ -259,9 +280,11 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 				totalTimeRemainingSeconds := int64(math.Round(remainingAccountDiscoveryTime + estimatedRescanTime))
 
 				// update address discovery progress, total progress and total time remaining
+				mw.syncData.mu.Lock()
 				mw.syncData.addressDiscoveryProgress.AddressDiscoveryProgress = int32(math.Round(discoveryProgress))
 				mw.syncData.addressDiscoveryProgress.TotalSyncProgress = totalProgressPercent
 				mw.syncData.addressDiscoveryProgress.TotalTimeRemainingSeconds = totalTimeRemainingSeconds
+				mw.syncData.mu.Unlock()
 
 				mw.publishAddressDiscoveryProgress()
 
@@ -273,7 +296,7 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 				}
 				mw.publishDebugInfo(debugInfo)
 
-				if mw.syncData.showLogs && mw.syncData.syncing {
+				if showLogs {
 					// avoid logging same message multiple times
 					if totalProgressPercent != lastTotalPercent || totalTimeRemainingSeconds != lastTimeRemaining {
 						log.Infof("Syncing %d%%, %s remaining, discovering used addresses.",
@@ -283,17 +306,15 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 						lastTimeRemaining = totalTimeRemainingSeconds
 					}
 				}
-				mw.syncData.mu.Unlock()
+
 			case <-mw.syncData.addressDiscoveryCompletedOrCanceled:
-				mw.syncData.mu.RLock()
 				// stop updating time taken and progress for address discovery
 				everySecondTicker.Stop()
 
-				if mw.syncData.showLogs && mw.syncData.syncing {
+				if showLogs {
 					log.Info("Address discovery complete.")
 				}
 
-				mw.syncData.mu.RUnlock()
 				return
 			}
 		}
@@ -301,38 +322,26 @@ func (mw *MultiWallet) updateAddressDiscoveryProgress() {
 }
 
 func (mw *MultiWallet) publishAddressDiscoveryProgress() {
-	if !mw.syncData.syncing {
-		// ignore if sync is not in progress
-		return
-	}
-
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.OnAddressDiscoveryProgress(&mw.syncData.activeSyncData.addressDiscoveryProgress)
 	}
 }
 
 func (mw *MultiWallet) discoverAddressesFinished(walletID int) {
 	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
-	if !mw.syncData.syncing {
-		// ignore if sync is not in progress
-		return
-	}
-
-	addressDiscoveryFinishTime := time.Now().Unix()
-	mw.syncData.activeSyncData.totalDiscoveryTimeSpent = addressDiscoveryFinishTime - mw.syncData.addressDiscoveryStartTime
 
 	close(mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled)
 	mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled = nil
+	mw.syncData.activeSyncData.totalDiscoveryTimeSpent = time.Now().Unix() - mw.syncData.addressDiscoveryStartTime
+
+	mw.syncData.mu.Unlock()
 
 	loadedWallet, loaded := mw.wallets[walletID].loader.LoadedWallet()
-	if loaded { // loaded should always be through
-		if !loadedWallet.Locked() {
-			loadedWallet.Lock()
-			err := mw.markWalletAsDiscoveredAccounts(walletID)
-			if err != nil {
-				log.Error(err)
-			}
+	if loaded && !loadedWallet.Locked() { // loaded should always be true
+		loadedWallet.Lock()
+		err := mw.markWalletAsDiscoveredAccounts(walletID)
+		if err != nil {
+			log.Error(err)
 		}
 	}
 
@@ -368,22 +377,17 @@ func (mw *MultiWallet) rescanStarted(walletID int) {
 }
 
 func (mw *MultiWallet) rescanProgress(walletID int, rescannedThrough int32) {
-	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
-
-	if !mw.syncData.syncing {
+	if !mw.IsSyncing() {
 		// ignore if sync is not in progress
 		return
 	}
 
 	wallet := mw.wallets[walletID]
+	totalHeadersToScan := wallet.GetBestBlock()
 
-	mw.syncData.activeSyncData.headersRescanProgress.WalletID = walletID
-	mw.syncData.activeSyncData.headersRescanProgress.TotalHeadersToScan = wallet.GetBestBlock()
+	rescanRate := float64(rescannedThrough) / float64(totalHeadersToScan)
 
-	rescanRate := float64(rescannedThrough) / float64(mw.syncData.activeSyncData.headersRescanProgress.TotalHeadersToScan)
-	mw.syncData.activeSyncData.headersRescanProgress.RescanProgress = int32(math.Round(rescanRate * 100))
-	mw.syncData.activeSyncData.headersRescanProgress.CurrentRescanHeight = rescannedThrough
+	mw.syncData.mu.Lock()
 
 	// If there was some period of inactivity,
 	// assume that this process started at some point in the future,
@@ -392,11 +396,15 @@ func (mw *MultiWallet) rescanProgress(walletID int, rescannedThrough int32) {
 	mw.syncData.activeSyncData.totalInactiveSeconds = 0
 
 	elapsedRescanTime := time.Now().Unix() - mw.syncData.activeSyncData.rescanStartTime
+	estimatedTotalRescanTime := int64(math.Round(float64(elapsedRescanTime) / rescanRate))
+	totalTimeRemainingSeconds := estimatedTotalRescanTime - elapsedRescanTime
 	totalElapsedTime := mw.syncData.activeSyncData.headersFetchTimeSpent + mw.syncData.activeSyncData.totalDiscoveryTimeSpent + elapsedRescanTime
 
-	estimatedTotalRescanTime := int64(math.Round(float64(elapsedRescanTime) / rescanRate))
-	mw.syncData.activeSyncData.headersRescanProgress.RescanTimeRemaining = estimatedTotalRescanTime - elapsedRescanTime
-	totalTimeRemainingSeconds := mw.syncData.activeSyncData.headersRescanProgress.RescanTimeRemaining
+	mw.syncData.activeSyncData.headersRescanProgress.WalletID = walletID
+	mw.syncData.activeSyncData.headersRescanProgress.TotalHeadersToScan = totalHeadersToScan
+	mw.syncData.activeSyncData.headersRescanProgress.RescanProgress = int32(math.Round(rescanRate * 100))
+	mw.syncData.activeSyncData.headersRescanProgress.CurrentRescanHeight = rescannedThrough
+	mw.syncData.activeSyncData.headersRescanProgress.RescanTimeRemaining = totalTimeRemainingSeconds
 
 	// do not update total time taken and total progress percent if elapsedRescanTime is 0
 	// because the estimatedTotalRescanTime will be inaccurate (also 0)
@@ -410,17 +418,20 @@ func (mw *MultiWallet) rescanProgress(walletID int, rescannedThrough int32) {
 		mw.syncData.activeSyncData.headersRescanProgress.TotalSyncProgress = int32(math.Round(totalProgress))
 	}
 
+	mw.syncData.mu.Unlock()
+
 	mw.publishHeadersRescanProgress()
 
 	debugInfo := &DebugInfo{
 		totalElapsedTime,
 		totalTimeRemainingSeconds,
 		elapsedRescanTime,
-		mw.syncData.activeSyncData.headersRescanProgress.RescanTimeRemaining,
+		totalTimeRemainingSeconds,
 	}
 	mw.publishDebugInfo(debugInfo)
 
-	if mw.syncData.showLogs && mw.syncData.syncing {
+	mw.syncData.mu.RLock()
+	if mw.syncData.showLogs {
 		log.Infof("Syncing %d%%, %s remaining, scanning %d of %d block headers.",
 			mw.syncData.activeSyncData.headersRescanProgress.TotalSyncProgress,
 			CalculateTotalTimeRemaining(mw.syncData.activeSyncData.headersRescanProgress.TotalTimeRemainingSeconds),
@@ -428,31 +439,32 @@ func (mw *MultiWallet) rescanProgress(walletID int, rescannedThrough int32) {
 			mw.syncData.activeSyncData.headersRescanProgress.TotalHeadersToScan,
 		)
 	}
+	mw.syncData.mu.RUnlock()
 }
 
 func (mw *MultiWallet) publishHeadersRescanProgress() {
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.OnHeadersRescanProgress(&mw.syncData.activeSyncData.headersRescanProgress)
 	}
 }
 
 func (mw *MultiWallet) rescanFinished(walletID int) {
-	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
-
-	if !mw.syncData.syncing {
+	if !mw.IsSyncing() {
 		// ignore if sync is not in progress
 		return
 	}
 
+	mw.syncData.mu.Lock()
 	mw.syncData.activeSyncData.headersRescanProgress.WalletID = walletID
 	mw.syncData.activeSyncData.headersRescanProgress.TotalTimeRemainingSeconds = 0
 	mw.syncData.activeSyncData.headersRescanProgress.TotalSyncProgress = 100
+	mw.syncData.mu.Unlock()
+
 	mw.publishHeadersRescanProgress()
 }
 
 func (mw *MultiWallet) publishDebugInfo(debugInfo *DebugInfo) {
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.Debug(debugInfo)
 	}
 }
@@ -460,9 +472,16 @@ func (mw *MultiWallet) publishDebugInfo(debugInfo *DebugInfo) {
 /** Helper functions start here */
 
 func (mw *MultiWallet) estimateBlockHeadersCountAfter(lastHeaderTime int64) int32 {
+	var targetTimePerBlock float64
+	if mw.chainParams.Name == "mainnet" {
+		targetTimePerBlock = MainNetTargetTimePerBlock
+	} else {
+		targetTimePerBlock = TestNetTargetTimePerBlock
+	}
+
 	// Use the difference between current time (now) and last reported block time, to estimate total headers to fetch
-	timeDifference := time.Now().Unix() - lastHeaderTime
-	estimatedHeadersDifference := float64(timeDifference) / float64(mw.syncData.activeSyncData.targetTimePerBlock)
+	timeDifference := float64(time.Now().Unix() - lastHeaderTime)
+	estimatedHeadersDifference := timeDifference / targetTimePerBlock
 
 	// return next integer value (upper limit) if estimatedHeadersDifference is a fraction
 	return int32(math.Ceil(estimatedHeadersDifference))
@@ -471,10 +490,7 @@ func (mw *MultiWallet) estimateBlockHeadersCountAfter(lastHeaderTime int64) int3
 func (mw *MultiWallet) notifySyncError(err error) {
 	mw.resetSyncData()
 
-	mw.syncData.mu.RLock()
-	defer mw.syncData.mu.RUnlock()
-
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
+	for _, syncProgressListener := range mw.syncProgressListeners() {
 		syncProgressListener.OnSyncEndedWithError(err)
 	}
 }
@@ -483,16 +499,22 @@ func (mw *MultiWallet) notifySyncCanceled() {
 	mw.resetSyncData()
 
 	mw.syncData.mu.RLock()
-	defer mw.syncData.mu.RUnlock()
+	restartSyncRequested := mw.syncData.restartSyncRequested
+	mw.syncData.mu.RUnlock()
 
-	for _, syncProgressListener := range mw.syncData.syncProgressListeners {
-		syncProgressListener.OnSyncCanceled(mw.syncData.restartSyncRequested)
+	for _, syncProgressListener := range mw.syncProgressListeners() {
+		syncProgressListener.OnSyncCanceled(restartSyncRequested)
 	}
 }
 
 func (mw *MultiWallet) resetSyncData() {
 	mw.syncData.mu.Lock()
 	defer mw.syncData.mu.Unlock()
+
+	if mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled != nil {
+		close(mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled)
+		mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled = nil
+	}
 
 	mw.syncData.syncing = false
 	mw.syncData.synced = false
@@ -504,19 +526,24 @@ func (mw *MultiWallet) resetSyncData() {
 }
 
 func (mw *MultiWallet) synced(walletID int, synced bool) {
-	mw.syncData.mu.Lock()
-	defer mw.syncData.mu.Unlock()
-	if mw.syncData.synced && synced {
+	mw.syncData.mu.RLock()
+	allWalletsSynced := mw.syncData.synced
+	mw.syncData.mu.RUnlock()
+
+	if allWalletsSynced && synced {
 		return
 	}
 
 	wallet := mw.wallets[walletID]
 	wallet.synced = synced
 	wallet.syncing = false
+
 	if mw.OpenedWalletsCount() == mw.SyncedWalletsCount() {
+		mw.syncData.mu.Lock()
 		mw.syncData.syncing = false
 		mw.syncData.synced = true
 		mw.syncData.activeSyncData = nil // to be reintialized on next sync
+		mw.syncData.mu.Unlock()
 
 		// begin indexing transactions after sync is completed,
 		// syncProgressListeners.OnSynced() will be invoked after transactions are indexed
@@ -531,8 +558,8 @@ func (mw *MultiWallet) synced(walletID int, synced bool) {
 				log.Errorf("Tx Index Error: %v", err)
 			}
 
-			for _, syncProgressListener := range mw.syncData.syncProgressListeners {
-				if mw.IsSynced() {
+			for _, syncProgressListener := range mw.syncProgressListeners() {
+				if allWalletsSynced {
 					syncProgressListener.OnSyncCompleted()
 				} else {
 					syncProgressListener.OnSyncCanceled(false)

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -221,7 +221,7 @@ func (mw *MultiWallet) discoverAddressesStarted(walletID int) {
 	mw.syncData.activeSyncData.addressDiscoveryStartTime = time.Now().Unix()
 	mw.syncData.activeSyncData.addressDiscoveryProgress.WalletID = walletID
 
-	if mw.syncData.showLogs && mw.syncData.syncing {
+	if mw.syncData.showLogs {
 		log.Info("Step 2 of 3 - discovering used addresses.")
 	}
 
@@ -486,15 +486,10 @@ func (mw *MultiWallet) publishDebugInfo(debugInfo *DebugInfo) {
 /** Helper functions start here */
 
 func (mw *MultiWallet) estimateBlockHeadersCountAfter(lastHeaderTime int64) int32 {
-	var targetTimePerBlock float64
-	if mw.chainParams.Name == "mainnet" {
-		targetTimePerBlock = MainNetTargetTimePerBlock
-	} else {
-		targetTimePerBlock = TestNetTargetTimePerBlock
-	}
-
-	// Use the difference between current time (now) and last reported block time, to estimate total headers to fetch
+	// Use the difference between current time (now) and last reported block time,
+	// to estimate total headers to fetch.
 	timeDifference := float64(time.Now().Unix() - lastHeaderTime)
+	targetTimePerBlock := float64(mw.chainParams.TargetTimePerBlock)
 	estimatedHeadersDifference := timeDifference / targetTimePerBlock
 
 	// return next integer value (upper limit) if estimatedHeadersDifference is a fraction

--- a/types.go
+++ b/types.go
@@ -80,8 +80,8 @@ type GeneralSyncProgress struct {
 type HeadersFetchProgressReport struct {
 	*GeneralSyncProgress
 	TotalHeadersToFetch    int32 `json:"totalHeadersToFetch"`
+	CurrentHeaderHeight    int32 `json:"currentHeaderHeight"`
 	CurrentHeaderTimestamp int64 `json:"currentHeaderTimestamp"`
-	FetchedHeadersCount    int32 `json:"fetchedHeadersCount"`
 	HeadersFetchProgress   int32 `json:"headersFetchProgress"`
 }
 

--- a/types.go
+++ b/types.go
@@ -61,7 +61,7 @@ type Accounts struct {
 /** begin sync-related types */
 
 type SyncProgressListener interface {
-	OnSyncStarted()
+	OnSyncStarted(wasRestarted bool)
 	OnPeerConnectedOrDisconnected(numberOfConnectedPeers int32)
 	OnHeadersFetchProgress(headersFetchProgress *HeadersFetchProgressReport)
 	OnAddressDiscoveryProgress(addressDiscoveryProgress *AddressDiscoveryProgressReport)

--- a/utils.go
+++ b/utils.go
@@ -21,12 +21,6 @@ import (
 const (
 	walletDbName = "wallet.db"
 
-	// Approximate time (in seconds) to mine a block in mainnet
-	MainNetTargetTimePerBlock = 300
-
-	// Approximate time (in seconds) to mine a block in testnet
-	TestNetTargetTimePerBlock = 120
-
 	// Use 10% of estimated total headers fetch time to estimate rescan time
 	RescanPercentage = 0.1
 


### PR DESCRIPTION
Ensures that access to ongoing sync data uses mutex locks held for as little time as possible to prevent delays when some other operation attempts to access ongoing sync data.

It is particularly important to unlock the syncData mutex before triggering sync progress listeners registered by client apps, since some of such listeners may perform long-running operations or even try to access ongoing sync data - in which case, an attempt will be made to lock the syncData mutex. In the latter scenario, the attempt to lock the mutex would lead to a deadlock if the mutex was not previously unlocked before the client-registered listener was invoked.

Also fixed a bug with `cancelSync` where initial syncing may have completed and the method is called to disconnect the wallets from the network backend.
https://github.com/raedahgroup/dcrlibwallet/blob/064d4c3c9998da7c04a9841726b16c34ced7e4fa/sync.go#L252-L258
The problem observed is that `mw.syncData.cancelSync` is not nil (even after initial sync completes because the wallets remain connected) but trying to access `mw.syncData.addressDiscoveryCompletedOrCanceled` panics because `mw.syncData.activeSyncData` would be nil (after initial sync completes) and `mw.syncData.addressDiscoveryCompletedOrCanceled` is actually `mw.syncData.activeSyncData.addressDiscoveryCompletedOrCanceled`.