### PR TITLE
multi: add multiwallet helper functions, fix link existing wallet bug, implement per-wallet config handling

### DIFF
--- a/address.go
+++ b/address.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/decred/dcrd/dcrutil/v2"
+	"github.com/decred/dcrwallet/errors/v2"
 	w "github.com/decred/dcrwallet/wallet/v3"
 	"github.com/decred/dcrwallet/wallet/v3/udb"
 )
@@ -69,6 +70,10 @@ func (wallet *Wallet) AddressInfo(address string) (*AddressInfo, error) {
 }
 
 func (wallet *Wallet) CurrentAddress(account int32) (string, error) {
+	if wallet.IsRestored && !wallet.HasDiscoveredAccounts {
+		return "", errors.E(ErrAddressDiscoveryNotDone)
+	}
+
 	addr, err := wallet.internal.CurrentAddress(uint32(account))
 	if err != nil {
 		log.Error(err)
@@ -78,6 +83,10 @@ func (wallet *Wallet) CurrentAddress(account int32) (string, error) {
 }
 
 func (wallet *Wallet) NextAddress(account int32) (string, error) {
+	if wallet.IsRestored && !wallet.HasDiscoveredAccounts {
+		return "", errors.E(ErrAddressDiscoveryNotDone)
+	}
+
 	addr, err := wallet.internal.NewExternalAddress(wallet.shutdownContext(), uint32(account), w.WithGapPolicyWrap())
 	if err != nil {
 		log.Error(err)

--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,7 @@ const (
 	ErrListenerAlreadyExist         = "listener_already_exist"
 	ErrLoggerAlreadyRegistered      = "logger_already_registered"
 	ErrLogRotatorAlreadyInitialized = "log_rotator_already_initialized"
+	ErrAddressDiscoveryNotDone      = "address_discovery_not_done"
 )
 
 // todo, should update this method to translate more error kinds.

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -301,6 +301,11 @@ func (mw *MultiWallet) RestoreWallet(seedMnemonic, privatePassphrase string, pri
 	}
 
 	return mw.saveNewWallet(wallet, func() error {
+		err := wallet.prepare(mw.rootDir, mw.chainParams)
+		if err != nil {
+			return err
+		}
+
 		return wallet.createWallet(privatePassphrase, seedMnemonic)
 	})
 }

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -220,7 +220,7 @@ func (mw *MultiWallet) StartupSecurityType() int32 {
 }
 
 func (mw *MultiWallet) OpenWallets(startupPassphrase []byte) error {
-	if mw.syncData.activeSyncData != nil {
+	if mw.IsSyncing() {
 		return errors.New(ErrSyncAlreadyInProgress)
 	}
 
@@ -327,7 +327,7 @@ func (mw *MultiWallet) LinkExistingWallet(walletDataDir, originalPubPass string,
 }
 
 func (mw *MultiWallet) addNewWallet(wallet *Wallet, finalizeWalletSetup func() error) (*Wallet, error) {
-	if mw.syncData.activeSyncData != nil {
+	if mw.IsSyncing() {
 		return nil, errors.New(ErrSyncAlreadyInProgress)
 	}
 
@@ -402,7 +402,7 @@ func (mw *MultiWallet) RenameWallet(walletID int, newName string) error {
 }
 
 func (mw *MultiWallet) DeleteWallet(walletID int, privPass []byte) error {
-	if mw.syncData.activeSyncData != nil {
+	if mw.IsSyncing() {
 		return errors.New(ErrSyncAlreadyInProgress)
 	}
 

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -426,15 +426,6 @@ func (mw *MultiWallet) DeleteWallet(walletID int, privPass []byte) error {
 	return nil
 }
 
-func (mw *MultiWallet) FirstOrDefaultWallet() *Wallet {
-	// todo consider implementing default wallet feature
-
-	for _, wallet := range mw.wallets {
-		return wallet
-	}
-	return nil
-}
-
 func (mw *MultiWallet) WalletWithID(walletID int) *Wallet {
 	if wallet, ok := mw.wallets[walletID]; ok {
 		return wallet

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -201,8 +201,8 @@ func (mw *MultiWallet) ChangeStartupPassphrase(oldPassphrase, newPassphrase []by
 		return err
 	}
 
-	mw.SaveUserConfigValue(isStartupSecuritySetConfigKey, true)
-	mw.SaveUserConfigValue(startupSecurityTypeConfigKey, passphraseType)
+	mw.SaveUserConfigValue(IsStartupSecuritySetConfigKey, true)
+	mw.SaveUserConfigValue(StartupSecurityTypeConfigKey, passphraseType)
 
 	return nil
 }
@@ -218,18 +218,18 @@ func (mw *MultiWallet) RemoveStartupPassphrase(oldPassphrase []byte) error {
 		return err
 	}
 
-	mw.SaveUserConfigValue(isStartupSecuritySetConfigKey, false)
-	mw.DeleteUserConfigValueForKey(startupSecurityTypeConfigKey)
+	mw.SaveUserConfigValue(IsStartupSecuritySetConfigKey, false)
+	mw.DeleteUserConfigValueForKey(StartupSecurityTypeConfigKey)
 
 	return nil
 }
 
 func (mw *MultiWallet) IsStartupSecuritySet() bool {
-	return mw.ReadBoolConfigValueForKey(isStartupSecuritySetConfigKey, false)
+	return mw.ReadBoolConfigValueForKey(IsStartupSecuritySetConfigKey, false)
 }
 
 func (mw *MultiWallet) StartupSecurityType() int32 {
-	return mw.ReadInt32ConfigValueForKey(startupSecurityTypeConfigKey, PassphraseTypePass)
+	return mw.ReadInt32ConfigValueForKey(StartupSecurityTypeConfigKey, PassphraseTypePass)
 }
 
 func (mw *MultiWallet) OpenWallets(startupPassphrase []byte) error {

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -104,7 +104,7 @@ func NewMultiWallet(rootDir, dbDriver, netType string) (*MultiWallet, error) {
 
 	mw.listenForShutdown()
 
-	logLevel := mw.ReadStringConfigValueForKey(LogLevelConfigKey, "")
+	logLevel := mw.ReadStringConfigValueForKey(LogLevelConfigKey)
 	SetLogLevels(logLevel)
 
 	log.Infof("Loaded %d wallets", mw.LoadedWalletsCount())

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -272,6 +272,7 @@ func (mw *MultiWallet) CreateNewWallet(privatePassphrase string, privatePassphra
 func (mw *MultiWallet) RestoreWallet(seedMnemonic, privatePassphrase string, privatePassphraseType int32) (*Wallet, error) {
 	wallet := &Wallet{
 		PrivatePassphraseType: privatePassphraseType,
+		IsRestored:            true,
 		HasDiscoveredAccounts: false,
 	}
 
@@ -288,6 +289,7 @@ func (mw *MultiWallet) LinkExistingWallet(walletDataDir, originalPubPass string,
 
 	wallet := &Wallet{
 		PrivatePassphraseType: privatePassphraseType,
+		IsRestored:            true,
 		HasDiscoveredAccounts: false, // assume that account discovery hasn't been done
 	}
 

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -140,11 +140,11 @@ func (mw *MultiWallet) Shutdown() {
 	}
 }
 
-// V1WalletExists checks if a wallet db file exists in `rootDir/{netType}`
-// as newer version wallets are no longer placed directly inside the
-// {netType} subdirectory of app data dir.
+// V1WalletExists checks if a wallet db file exists in `mw.rootDir`
+// as newer version wallets are no longer placed directly inside `mw.rootDir`
+// but in subdirectories instead.
 func (mw *MultiWallet) V1WalletExists() bool {
-	return V1WalletExistsAt(mw.rootDir, mw.chainParams.Name)
+	return WalletExistsAt(mw.rootDir)
 }
 
 // MigrateV1Wallet checks if a v1 wallet exists in `mw.rootDir` and
@@ -296,8 +296,10 @@ func (mw *MultiWallet) RestoreWallet(seedMnemonic, privatePassphrase string, pri
 }
 
 func (mw *MultiWallet) LinkExistingWallet(walletDataDir, originalPubPass string, privatePassphraseType int32) (*Wallet, error) {
+	// todo: confirm that the wallet being linked is of the same netType as this multiwallet instance.
+
 	// check if `walletDataDir` contains wallet.db
-	if !V1WalletExistsAt(walletDataDir, mw.chainParams.Name) {
+	if !WalletExistsAt(walletDataDir) {
 		return nil, errors.New(ErrNotExist)
 	}
 
@@ -308,8 +310,6 @@ func (mw *MultiWallet) LinkExistingWallet(walletDataDir, originalPubPass string,
 	}
 
 	return mw.addNewWallet(wallet, func() error {
-		walletDataDir = filepath.Join(walletDataDir, mw.chainParams.Name)
-
 		// move wallet.db and tx.db files to newly created dir for the wallet
 		currentWalletDbFilePath := filepath.Join(walletDataDir, walletDbName)
 		newWalletDbFilePath := filepath.Join(wallet.dataDir, walletDbName)

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -139,20 +139,6 @@ func (mw *MultiWallet) Shutdown() {
 	}
 }
 
-// V1WalletExists checks if a wallet db file exists in `mw.rootDir`
-// as newer version wallets are no longer placed directly inside `mw.rootDir`
-// but in subdirectories instead.
-func (mw *MultiWallet) V1WalletExists() bool {
-	return WalletExistsAt(mw.rootDir)
-}
-
-// MigrateV1Wallet checks if a v1 wallet exists in `mw.rootDir` and
-// links/adds it as an additional database to this multiwallet instance.
-func (mw *MultiWallet) MigrateV1Wallet(originalPubPass string, originalPrivatePassType int32) error {
-	_, err := mw.LinkExistingWallet(mw.rootDir, originalPubPass, originalPrivatePassType)
-	return err
-}
-
 func (mw *MultiWallet) SetStartupPassphrase(passphrase []byte, passphraseType int32) error {
 	return mw.ChangeStartupPassphrase([]byte(""), passphrase, passphraseType)
 }
@@ -429,7 +415,7 @@ func (mw *MultiWallet) saveNewWallet(wallet *Wallet, setupWallet func() error) (
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, translateError(err)
 	}
 
 	mw.wallets[wallet.ID] = wallet

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -140,6 +140,20 @@ func (mw *MultiWallet) Shutdown() {
 	}
 }
 
+// V1WalletExists checks if a wallet db file exists in `rootDir/{netType}`
+// as newer version wallets are no longer placed directly inside the
+// {netType} subdirectory of app data dir.
+func (mw *MultiWallet) V1WalletExists() bool {
+	return V1WalletExistsAt(mw.rootDir, mw.chainParams.Name)
+}
+
+// MigrateV1Wallet checks if a v1 wallet exists in `mw.rootDir` and
+// links/adds it as an additional database to this multiwallet instance.
+func (mw *MultiWallet) MigrateV1Wallet(originalPubPass string, originalPrivatePassType int32) error {
+	_, err := mw.LinkExistingWallet(mw.rootDir, originalPubPass, originalPrivatePassType)
+	return err
+}
+
 func (mw *MultiWallet) SetStartupPassphrase(passphrase []byte, passphraseType int32) error {
 	return mw.ChangeStartupPassphrase([]byte(""), passphrase, passphraseType)
 }
@@ -283,7 +297,7 @@ func (mw *MultiWallet) RestoreWallet(seedMnemonic, privatePassphrase string, pri
 
 func (mw *MultiWallet) LinkExistingWallet(walletDataDir, originalPubPass string, privatePassphraseType int32) (*Wallet, error) {
 	// check if `walletDataDir` contains wallet.db
-	if !WalletExistsAt(walletDataDir, mw.chainParams.Name) {
+	if !V1WalletExistsAt(walletDataDir, mw.chainParams.Name) {
 		return nil, errors.New(ErrNotExist)
 	}
 

--- a/multiwallet_config.go
+++ b/multiwallet_config.go
@@ -12,8 +12,8 @@ const (
 	SpendUnconfirmedConfigKey   = "spend_unconfirmed"
 	CurrencyConversionConfigKey = "currency_conversion_option"
 
-	isStartupSecuritySetConfigKey = "startup_security_set"
-	startupSecurityTypeConfigKey  = "startup_security_type"
+	IsStartupSecuritySetConfigKey = "startup_security_set"
+	StartupSecurityTypeConfigKey  = "startup_security_type"
 	UseFingerprintConfigKey       = "use_fingerprint"
 
 	IncomingTxNotificationsConfigKey = "tx_notification_enabled"

--- a/multiwallet_config.go
+++ b/multiwallet_config.go
@@ -137,9 +137,7 @@ func (mw *MultiWallet) ReadLongConfigValueForKey(key string, defaultValue int64)
 	return
 }
 
-func (mw *MultiWallet) ReadStringConfigValueForKey(key string, defaultValue string) (valueOut string) {
-	if err := mw.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
-		valueOut = defaultValue
-	}
+func (mw *MultiWallet) ReadStringConfigValueForKey(key string) (valueOut string) {
+	mw.ReadUserConfigValue(key, &valueOut)
 	return
 }

--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -1,8 +1,11 @@
 package dcrlibwallet
 
 import (
+	"context"
+
 	"github.com/asdine/storm"
 	"github.com/decred/dcrwallet/errors/v2"
+	w "github.com/decred/dcrwallet/wallet/v3"
 	"github.com/raedahgroup/dcrlibwallet/spv"
 )
 
@@ -35,6 +38,32 @@ func (mw *MultiWallet) batchDbTransaction(dbOp func(node storm.Node) error) (err
 	err = dbOp(dbTx)
 	panicked = false
 	return err
+}
+
+func (mw *MultiWallet) loadWalletTemporarily(ctx context.Context, walletDataDir, walletPublicPass string,
+	onLoaded func(*w.Wallet) error) error {
+
+	if walletPublicPass == "" {
+		walletPublicPass = w.InsecurePubPassphrase
+	}
+
+	// initialize the wallet loader
+	walletLoader := initWalletLoader(mw.chainParams, walletDataDir, mw.dbDriver)
+
+	// open the wallet to get ready for temporary use
+	wallet, err := walletLoader.OpenExistingWallet(ctx, []byte(walletPublicPass))
+	if err != nil {
+		return err
+	}
+
+	// unload wallet after temporary use
+	defer walletLoader.UnloadWallet()
+
+	if onLoaded != nil {
+		return onLoaded(wallet)
+	}
+
+	return nil
 }
 
 func (mw *MultiWallet) markWalletAsDiscoveredAccounts(walletID int) error {

--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -77,6 +77,7 @@ func (mw *MultiWallet) markWalletAsDiscoveredAccounts(walletID int) error {
 		return err
 	}
 
+	log.Infof("Set discovered accounts = true for wallet %d", wallet.ID)
 	wallet.HasDiscoveredAccounts = true
 	err = mw.db.Save(wallet)
 	if err != nil {

--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -53,7 +53,7 @@ func (mw *MultiWallet) loadWalletTemporarily(ctx context.Context, walletDataDir,
 	// open the wallet to get ready for temporary use
 	wallet, err := walletLoader.OpenExistingWallet(ctx, []byte(walletPublicPass))
 	if err != nil {
-		return err
+		return translateError(err)
 	}
 
 	// unload wallet after temporary use

--- a/sync.go
+++ b/sync.go
@@ -175,7 +175,7 @@ func (mw *MultiWallet) SyncInactiveForPeriod(totalInactiveSeconds int64) {
 
 func (mw *MultiWallet) SpvSync() error {
 	// prevent an attempt to sync when the previous syncing has not been canceled
-	if mw.syncData.cancelSync != nil || mw.syncData.activeSyncData != nil {
+	if mw.IsSyncing() || mw.IsSynced() {
 		return errors.New(ErrSyncAlreadyInProgress)
 	}
 

--- a/sync.go
+++ b/sync.go
@@ -184,7 +184,7 @@ func (mw *MultiWallet) SpvSync() error {
 	lp := p2p.NewLocalPeer(mw.chainParams, addr, addrManager)
 
 	var validPeerAddresses []string
-	peerAddresses := mw.ReadStringConfigValueForKey(SpvPersistentPeerAddressesConfigKey, "")
+	peerAddresses := mw.ReadStringConfigValueForKey(SpvPersistentPeerAddressesConfigKey)
 	if peerAddresses != "" {
 		addresses := strings.Split(peerAddresses, ";")
 		for _, address := range addresses {

--- a/txandblocknotifications.go
+++ b/txandblocknotifications.go
@@ -41,6 +41,10 @@ func (mw *MultiWallet) listenForTransactions(walletID int) {
 
 		for _, block := range v.AttachedBlocks {
 			blockHash := block.Header.BlockHash()
+
+			log.Infof("[%d] New Block %d", wallet.ID, block.Header.Height)
+			mw.publishBlockAttached(wallet.ID, int32(block.Header.Height))
+
 			for _, transaction := range block.Transactions {
 				tempTransaction, err := wallet.decodeTransactionWithTxSummary(&transaction, &blockHash)
 				if err != nil {
@@ -53,10 +57,10 @@ func (mw *MultiWallet) listenForTransactions(walletID int) {
 					log.Errorf("[%d] Incoming block replace tx error :%v", wallet.ID, err)
 					return
 				}
+
+				log.Infof("[%d] Confirmed Transaction %s", wallet.ID, tempTransaction.Hash)
 				mw.publishTransactionConfirmed(wallet.ID, transaction.Hash.String(), int32(block.Header.Height))
 			}
-
-			mw.publishBlockAttached(wallet.ID, int32(block.Header.Height))
 		}
 	}
 }

--- a/txandblocknotifications.go
+++ b/txandblocknotifications.go
@@ -41,10 +41,6 @@ func (mw *MultiWallet) listenForTransactions(walletID int) {
 
 		for _, block := range v.AttachedBlocks {
 			blockHash := block.Header.BlockHash()
-
-			log.Infof("[%d] New Block %d", wallet.ID, block.Header.Height)
-			mw.publishBlockAttached(wallet.ID, int32(block.Header.Height))
-
 			for _, transaction := range block.Transactions {
 				tempTransaction, err := wallet.decodeTransactionWithTxSummary(&transaction, &blockHash)
 				if err != nil {
@@ -57,10 +53,10 @@ func (mw *MultiWallet) listenForTransactions(walletID int) {
 					log.Errorf("[%d] Incoming block replace tx error :%v", wallet.ID, err)
 					return
 				}
-
-				log.Infof("[%d] Confirmed Transaction %s", wallet.ID, tempTransaction.Hash)
 				mw.publishTransactionConfirmed(wallet.ID, transaction.Hash.String(), int32(block.Header.Height))
 			}
+
+			mw.publishBlockAttached(wallet.ID, int32(block.Header.Height))
 		}
 	}
 }

--- a/types.go
+++ b/types.go
@@ -2,6 +2,11 @@ package dcrlibwallet
 
 import "github.com/decred/dcrwallet/wallet/v3"
 
+type WalletsIterator struct {
+	currentIndex int
+	wallets      []*Wallet
+}
+
 type BlockInfo struct {
 	Height    int32
 	Timestamp int64

--- a/utils.go
+++ b/utils.go
@@ -12,10 +12,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrd/hdkeychain/v2"
 	"github.com/decred/dcrwallet/errors/v2"
+	"github.com/decred/dcrwallet/wallet/v3"
+	"github.com/decred/dcrwallet/wallet/v3/txrules"
 	"github.com/decred/dcrwallet/walletseed"
+	"github.com/raedahgroup/dcrlibwallet/internal/loader"
 )
 
 const (
@@ -226,4 +230,30 @@ func fileExists(filePath string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func moveFile(sourcePath, destinationPath string) error {
+	if exists, _ := fileExists(sourcePath); exists {
+		return os.Rename(sourcePath, destinationPath)
+	}
+	return nil
+}
+
+func initWalletLoader(chainParams *chaincfg.Params, walletDataDir, walletDbDriver string) *loader.Loader {
+	defaultFeePerKb := txrules.DefaultRelayFeePerKb.ToCoin()
+	stakeOptions := &loader.StakeOptions{
+		VotingEnabled: false,
+		AddressReuse:  false,
+		VotingAddress: nil,
+		TicketFee:     defaultFeePerKb,
+	}
+
+	walletLoader := loader.NewLoader(chainParams, walletDataDir, stakeOptions, 20, false,
+		defaultFeePerKb, wallet.DefaultAccountGapLimit, false)
+
+	if walletDbDriver != "" {
+		walletLoader.SetDatabaseDriver(walletDbDriver)
+	}
+
+	return walletLoader
 }

--- a/utils.go
+++ b/utils.go
@@ -208,8 +208,8 @@ func roundUp(n float64) int32 {
 	return int32(math.Round(n))
 }
 
-func WalletExistsAt(walletDataDir, netType string) bool {
-	walletDbFilePath := filepath.Join(walletDataDir, netType, walletDbName)
+func V1WalletExistsAt(rootDir, netType string) bool {
+	walletDbFilePath := filepath.Join(rootDir, netType, walletDbName)
 	exists, err := fileExists(walletDbFilePath)
 	if err != nil {
 		log.Errorf("wallet exists check error: %v", err)

--- a/utils.go
+++ b/utils.go
@@ -208,8 +208,8 @@ func roundUp(n float64) int32 {
 	return int32(math.Round(n))
 }
 
-func V1WalletExistsAt(rootDir, netType string) bool {
-	walletDbFilePath := filepath.Join(rootDir, netType, walletDbName)
+func WalletExistsAt(directory string) bool {
+	walletDbFilePath := filepath.Join(directory, walletDbName)
 	exists, err := fileExists(walletDbFilePath)
 	if err != nil {
 		log.Errorf("wallet exists check error: %v", err)

--- a/utils.go
+++ b/utils.go
@@ -212,6 +212,10 @@ func roundUp(n float64) int32 {
 	return int32(math.Round(n))
 }
 
+func WalletUniqueConfigKey(walletID int, key string) string {
+	return fmt.Sprintf("%d%s", walletID, key)
+}
+
 func WalletExistsAt(directory string) bool {
 	walletDbFilePath := filepath.Join(directory, walletDbName)
 	exists, err := fileExists(walletDbFilePath)

--- a/wallet.go
+++ b/wallet.go
@@ -10,7 +10,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	w "github.com/decred/dcrwallet/wallet/v3"
-	"github.com/decred/dcrwallet/wallet/v3/txrules"
 	"github.com/decred/dcrwallet/walletseed"
 	"github.com/raedahgroup/dcrlibwallet/internal/loader"
 	"github.com/raedahgroup/dcrlibwallet/txindex"
@@ -56,18 +55,7 @@ func (wallet *Wallet) prepare(rootDir string, chainParams *chaincfg.Params) (err
 	}
 
 	// init loader
-	defaultFeePerKb := txrules.DefaultRelayFeePerKb.ToCoin()
-	stakeOptions := &loader.StakeOptions{
-		VotingEnabled: false,
-		AddressReuse:  false,
-		VotingAddress: nil,
-		TicketFee:     defaultFeePerKb,
-	}
-	wallet.loader = loader.NewLoader(wallet.chainParams, wallet.dataDir, stakeOptions, 20, false,
-		defaultFeePerKb, w.DefaultAccountGapLimit, false)
-	if wallet.DbDriver != "" {
-		wallet.loader.SetDatabaseDriver(wallet.DbDriver)
-	}
+	wallet.loader = initWalletLoader(wallet.chainParams, wallet.dataDir, wallet.DbDriver)
 
 	// init cancelFuncs slice to hold cancel functions for long running
 	// operations and start go routine to listen for shutdown signal

--- a/wallet.go
+++ b/wallet.go
@@ -21,6 +21,7 @@ type Wallet struct {
 	Name                        string `storm:"unique"`
 	DbDriver                    string
 	Seed                        string
+	IsRestored                  bool
 	HasDiscoveredAccounts       bool
 	PrivatePassphraseType       int32
 	IncomingTxNotificationsPref string

--- a/wallet_config.go
+++ b/wallet_config.go
@@ -1,0 +1,97 @@
+package dcrlibwallet
+
+import (
+	"github.com/asdine/storm"
+	"github.com/decred/dcrwallet/errors/v2"
+)
+
+func (wallet *Wallet) SaveUserConfigValue(key string, value interface{}) {
+	if wallet.setUserConfigValue == nil {
+		log.Errorf("call wallet.prepare before setting wallet config values")
+		return
+	}
+
+	err := wallet.setUserConfigValue(key, value)
+	if err != nil {
+		log.Errorf("error setting config value for key: %s, error: %v", key, err)
+	}
+}
+
+func (wallet *Wallet) ReadUserConfigValue(key string, valueOut interface{}) error {
+	if wallet.setUserConfigValue == nil {
+		log.Errorf("call wallet.prepare before reading wallet config values")
+		return errors.New(ErrFailedPrecondition)
+	}
+
+	err := wallet.readUserConfigValue(key, valueOut)
+	if err != nil && err != storm.ErrNotFound {
+		log.Errorf("error reading config value for key: %s, error: %v", key, err)
+	}
+	return err
+}
+
+func (wallet *Wallet) SetBoolConfigValueForKey(key string, value bool) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) SetDoubleConfigValueForKey(key string, value float64) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) SetIntConfigValueForKey(key string, value int) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) SetInt32ConfigValueForKey(key string, value int32) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) SetLongConfigValueForKey(key string, value int64) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) SetStringConfigValueForKey(key, value string) {
+	wallet.SaveUserConfigValue(key, value)
+}
+
+func (wallet *Wallet) ReadBoolConfigValueForKey(key string, defaultValue bool) (valueOut bool) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}
+
+func (wallet *Wallet) ReadDoubleConfigValueForKey(key string, defaultValue float64) (valueOut float64) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}
+
+func (wallet *Wallet) ReadIntConfigValueForKey(key string, defaultValue int) (valueOut int) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}
+
+func (wallet *Wallet) ReadInt32ConfigValueForKey(key string, defaultValue int32) (valueOut int32) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}
+
+func (wallet *Wallet) ReadLongConfigValueForKey(key string, defaultValue int64) (valueOut int64) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}
+
+func (wallet *Wallet) ReadStringConfigValueForKey(key string, defaultValue string) (valueOut string) {
+	if err := wallet.ReadUserConfigValue(key, &valueOut); err == storm.ErrNotFound {
+		valueOut = defaultValue
+	}
+	return
+}

--- a/wallets.go
+++ b/wallets.go
@@ -1,0 +1,29 @@
+package dcrlibwallet
+
+func (mw *MultiWallet) AllWallets() (wallets []*Wallet) {
+	for _, wallet := range mw.wallets {
+		wallets = append(wallets, wallet)
+	}
+	return wallets
+}
+
+func (mw *MultiWallet) WalletsIterator() *WalletsIterator {
+	return &WalletsIterator{
+		currentIndex: 0,
+		wallets: mw.AllWallets(),
+	}
+}
+
+func (walletsIterator *WalletsIterator) Next() *Wallet {
+	if walletsIterator.currentIndex < len(walletsIterator.wallets) {
+		wallet := walletsIterator.wallets[walletsIterator.currentIndex]
+		walletsIterator.currentIndex++
+		return wallet
+	}
+
+	return nil
+}
+
+func (walletsIterator *WalletsIterator) Reset() {
+	walletsIterator.currentIndex = 0
+}

--- a/wallets.go
+++ b/wallets.go
@@ -10,7 +10,7 @@ func (mw *MultiWallet) AllWallets() (wallets []*Wallet) {
 func (mw *MultiWallet) WalletsIterator() *WalletsIterator {
 	return &WalletsIterator{
 		currentIndex: 0,
-		wallets: mw.AllWallets(),
+		wallets:      mw.AllWallets(),
 	}
 }
 


### PR DESCRIPTION
- `AllWallets()` and `WalletsIterator()` methods for client apps to access all wallets info
- Add `wallet.IsRestored` property to track restored wallets and ensure that address discovery is completed for such wallets before new addresses are derived.
- Fix bug with linking an existing wallet that uses a non-default public passphrase. Also added helper methods for easily migrating v1 wallets to the new multiwallet structure.
- Implement wallet-specific config reading/writing.