### PR TITLE
fix bug with sync headers fetching progress calculation

### DIFF
--- a/syncnotification.go
+++ b/syncnotification.go
@@ -484,7 +484,7 @@ func (mw *MultiWallet) estimateBlockHeadersCountAfter(lastHeaderTime int64) int3
 	// Use the difference between current time (now) and last reported block time,
 	// to estimate total headers to fetch.
 	timeDifferenceInSeconds := float64(time.Now().Unix() - lastHeaderTime)
-	targetTimePerBlockInSeconds := float64(mw.chainParams.TargetTimePerBlock.Seconds())
+	targetTimePerBlockInSeconds := mw.chainParams.TargetTimePerBlock.Seconds()
 	estimatedHeadersDifference := timeDifferenceInSeconds / targetTimePerBlockInSeconds
 
 	// return next integer value (upper limit) if estimatedHeadersDifference is a fraction

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -483,9 +483,9 @@ func (mw *MultiWallet) publishDebugInfo(debugInfo *DebugInfo) {
 func (mw *MultiWallet) estimateBlockHeadersCountAfter(lastHeaderTime int64) int32 {
 	// Use the difference between current time (now) and last reported block time,
 	// to estimate total headers to fetch.
-	timeDifference := float64(time.Now().Unix() - lastHeaderTime)
-	targetTimePerBlock := float64(mw.chainParams.TargetTimePerBlock)
-	estimatedHeadersDifference := timeDifference / targetTimePerBlock
+	timeDifferenceInSeconds := float64(time.Now().Unix() - lastHeaderTime)
+	targetTimePerBlockInSeconds := float64(mw.chainParams.TargetTimePerBlock.Seconds())
+	estimatedHeadersDifference := timeDifferenceInSeconds / targetTimePerBlockInSeconds
 
 	// return next integer value (upper limit) if estimatedHeadersDifference is a fraction
 	return int32(math.Ceil(estimatedHeadersDifference))


### PR DESCRIPTION
Sync headers fetch progress constantly shows 100% because it is unable to correctly estimate the number of headers remaining to be fetched. This PR fixes that estimation code.