### PR TITLE
add/rename/delete config fields and methods

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package dcrlibwallet
 
 import (
 	"github.com/asdine/storm"
+	"github.com/decred/dcrwallet/errors/v2"
 )
 
 const (
@@ -124,4 +125,14 @@ func (mw *MultiWallet) ReadStringConfigValueForKey(key string, defaultValue stri
 		valueOut = defaultValue
 	}
 	return
+}
+
+func (mw *MultiWallet) UpdateIncomingNotificationsUserPreference(walletID int, notificationsPref string) error {
+	wallet := mw.WalletWithID(walletID)
+	if wallet == nil {
+		return errors.New(ErrNotExist)
+	}
+
+	wallet.IncomingTxNotificationsPref = notificationsPref
+	return translateError(mw.db.Save(wallet))
 }

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ const (
 	startupSecurityTypeConfigKey  = "startup_security_type"
 	UseFingerprintConfigKey       = "use_fingerprint"
 
-	BeepNewBlocksConfigKey           = "beep_new_blocks"
+	BeepNewBlocksConfigKey = "beep_new_blocks"
 
 	SyncOnCellularConfigKey             = "always_sync"
 	NetworkModeConfigKey                = "network_mode"

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -185,8 +185,8 @@ func (mw *MultiWallet) ChangeStartupPassphrase(oldPassphrase, newPassphrase []by
 		return err
 	}
 
-	mw.SaveUserConfigValue(IsStartupSecuritySetConfigKey, true)
-	mw.SaveUserConfigValue(StartupSecurityTypeConfigKey, passphraseType)
+	mw.SaveUserConfigValue(isStartupSecuritySetConfigKey, true)
+	mw.SaveUserConfigValue(startupSecurityTypeConfigKey, passphraseType)
 
 	return nil
 }
@@ -202,8 +202,8 @@ func (mw *MultiWallet) RemoveStartupPassphrase(oldPassphrase []byte) error {
 		return err
 	}
 
-	mw.SaveUserConfigValue(IsStartupSecuritySetConfigKey, false)
-	mw.DeleteUserConfigValue(StartupSecurityTypeConfigKey)
+	mw.SaveUserConfigValue(isStartupSecuritySetConfigKey, false)
+	mw.DeleteUserConfigValueForKey(startupSecurityTypeConfigKey)
 
 	return nil
 }

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -105,6 +105,9 @@ func NewMultiWallet(rootDir, dbDriver, netType string) (*MultiWallet, error) {
 
 	mw.listenForShutdown()
 
+	logLevel := mw.ReadStringConfigValueForKey(LogLevelConfigKey, "")
+	SetLogLevels(logLevel)
+
 	log.Infof("Loaded %d wallets", mw.LoadedWalletsCount())
 
 	return mw, nil
@@ -206,6 +209,14 @@ func (mw *MultiWallet) RemoveStartupPassphrase(oldPassphrase []byte) error {
 	mw.DeleteUserConfigValueForKey(startupSecurityTypeConfigKey)
 
 	return nil
+}
+
+func (mw *MultiWallet) IsStartupSecuritySet() bool {
+	return mw.ReadBoolConfigValueForKey(isStartupSecuritySetConfigKey, false)
+}
+
+func (mw *MultiWallet) StartupSecurityType() int32 {
+	return mw.ReadInt32ConfigValueForKey(startupSecurityTypeConfigKey, PassphraseTypePass)
 }
 
 func (mw *MultiWallet) OpenWallets(startupPassphrase []byte) error {

--- a/sync.go
+++ b/sync.go
@@ -184,7 +184,7 @@ func (mw *MultiWallet) SpvSync() error {
 	lp := p2p.NewLocalPeer(mw.chainParams, addr, addrManager)
 
 	var validPeerAddresses []string
-	peerAddresses := mw.ReadStringConfigValueForKey(SpvPersistentPeerAddressesConfigKey)
+	peerAddresses := mw.ReadStringConfigValueForKey(SpvPersistentPeerAddressesConfigKey, "")
 	if peerAddresses != "" {
 		addresses := strings.Split(peerAddresses, ";")
 		for _, address := range addresses {

--- a/wallet.go
+++ b/wallet.go
@@ -17,12 +17,13 @@ import (
 )
 
 type Wallet struct {
-	ID                    int    `storm:"id,increment"`
-	Name                  string `storm:"unique"`
-	DbDriver              string
-	Seed                  string
-	PrivatePassphraseType int32
-	HasDiscoveredAccounts bool
+	ID                          int    `storm:"id,increment"`
+	Name                        string `storm:"unique"`
+	DbDriver                    string
+	Seed                        string
+	HasDiscoveredAccounts       bool
+	PrivatePassphraseType       int32
+	IncomingTxNotificationsPref string
 
 	internal    *w.Wallet
 	chainParams *chaincfg.Params


### PR DESCRIPTION
Also
- Unexport startup security config keys to prevent overriding those values from outside dcrlibwallet.
- Add helper methods to read startup security config values.
- Set log levels on multiwallet initialization using user preference saved in config.
