### PR TITLE
lock wallets if sync errors or is canceled

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -208,6 +208,7 @@ func (mw *MultiWallet) SpvSync() error {
 	wallets := make(map[int]*w.Wallet)
 	for id, wallet := range mw.wallets {
 		wallets[id] = wallet.internal
+		wallet.syncing = true
 	}
 
 	syncer := spv.NewSyncer(wallets, lp)
@@ -297,6 +298,14 @@ func (mw *MultiWallet) CancelSync() {
 
 func (wallet *Wallet) IsWaiting() bool {
 	return wallet.waiting
+}
+
+func (wallet *Wallet) IsSynced() bool {
+	return wallet.synced
+}
+
+func (wallet *Wallet) IsSyncing() bool {
+	return wallet.syncing
 }
 
 func (mw *MultiWallet) IsSynced() bool {

--- a/sync.go
+++ b/sync.go
@@ -208,6 +208,7 @@ func (mw *MultiWallet) SpvSync() error {
 	wallets := make(map[int]*w.Wallet)
 	for id, wallet := range mw.wallets {
 		wallets[id] = wallet.internal
+		wallet.waiting = true
 		wallet.syncing = true
 	}
 

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -522,6 +522,7 @@ func (mw *MultiWallet) resetSyncData() {
 
 	for _, wallet := range mw.wallets {
 		wallet.waiting = true
+		wallet.LockWallet() // lock wallet if previously unlocked to perform account discovery.
 	}
 }
 
@@ -537,6 +538,7 @@ func (mw *MultiWallet) synced(walletID int, synced bool) {
 	wallet := mw.wallets[walletID]
 	wallet.synced = synced
 	wallet.syncing = false
+	wallet.LockWallet() // lock wallet if previously unlocked to perform account discovery.
 
 	if mw.OpenedWalletsCount() == mw.SyncedWalletsCount() {
 		mw.syncData.mu.Lock()


### PR DESCRIPTION
Wallets are sometimes unlocked without a time limit before sync is started, so that accounts discovery may be performed.

Currently, such wallets are only re-locked when account discovery completes. This PR ensures that all wallets are re-locked even if sync is canceled or errors before account discovery completes.

Also,
- export wallet.IsSyncing() and wallet.IsSynced()