### PR TITLE
rescan: send a notification when rescanning starts

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -603,6 +603,9 @@ func (lw *LibWallet) RescanBlocks() error {
 		defer func() {
 			lw.rescannning = false
 		}()
+		for _, syncResponse := range lw.syncResponses {
+			syncResponse.OnRescan(0, START)
+		}
 		lw.rescannning = true
 		progress := make(chan wallet.RescanProgress, 1)
 		ctx := shutdownContext()


### PR DESCRIPTION
Fixes a bug that causes rescan remaining time estimation to be way off. The bug occurred because the rescan function was not sending a notification when rescan started which is when dcrandroid resets the estimates and the fix was done by sending a “rescan started” to the registered notification listeners.