### PR TITLE
send: prevent address gap limit exhaustion in change generation

### DIFF
--- a/dcrlibwallet.go
+++ b/dcrlibwallet.go
@@ -15,6 +15,7 @@ import (
 	"github.com/decred/dcrwallet/wallet/v3"
 	"github.com/decred/dcrwallet/wallet/v3/txrules"
 	"github.com/raedahgroup/dcrlibwallet/internal/loader"
+	"github.com/raedahgroup/dcrlibwallet/txhelper"
 	"github.com/raedahgroup/dcrlibwallet/utils"
 	bolt "go.etcd.io/bbolt"
 )
@@ -33,6 +34,8 @@ type LibWallet struct {
 	wallet        *wallet.Wallet
 	txDB          *storm.DB
 	*syncData
+
+	changeSource *txhelper.TxChangeSource
 
 	shuttingDown chan bool
 	cancelFuncs  []context.CancelFunc

--- a/txhelper/changesource.go
+++ b/txhelper/changesource.go
@@ -6,27 +6,29 @@ import (
 )
 
 // implements Script() and ScriptSize() functions of txauthor.ChangeSource
-type txChangeSource struct {
-	version uint16
-	script  []byte
+type TxChangeSource struct {
+	SrcAccount int32
+	version    uint16
+	script     []byte
 }
 
-func (src *txChangeSource) Script() ([]byte, uint16, error) {
+func (src *TxChangeSource) Script() ([]byte, uint16, error) {
 	return src.script, src.version, nil
 }
 
-func (src *txChangeSource) ScriptSize() int {
+func (src *TxChangeSource) ScriptSize() int {
 	return len(src.script)
 }
 
-func MakeTxChangeSource(destAddr string, net dcrutil.AddressParams) (*txChangeSource, error) {
+func MakeTxChangeSource(srcAccount int32, destAddr string, net dcrutil.AddressParams) (*TxChangeSource, error) {
 	pkScript, err := addresshelper.PkScript(destAddr, net)
 	if err != nil {
 		return nil, err
 	}
-	changeSource := &txChangeSource{
-		script:  pkScript,
-		version: addresshelper.DefaultScriptVersion,
+	changeSource := &TxChangeSource{
+		SrcAccount: srcAccount,
+		script:     pkScript,
+		version:    addresshelper.DefaultScriptVersion,
 	}
 	return changeSource, nil
 }


### PR DESCRIPTION
This fixes a gap limit exhaustion error caused by calling `constructTransaction` multiple times which causes the wallet to keep generating change addresses until exhaustion. This error is fixed by using gap policy 'wrap' which configures the address generation method to wrap around to a previously returned address instead of erroring or ignoring the gap limit and returning a new unused address. The change source created during `constructTransaction` is saved, reused throughout the current session and discarded after publishing transaction.

Addresses #110 

Error Message: 
`[ERR] DLWL: wallet.NewUnsignedTransaction: policy violation:: txauthor.NewUnsignedTransaction: generating next address violates the unused address gap limit policy`