### PR TITLE
send: change NewUnsignedTx to multiwallet method, add TxAuthor helper methods

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -9,8 +9,8 @@ import (
 	"github.com/decred/dcrwallet/errors/v2"
 )
 
-func (wallet *Wallet) GetAccounts(requiredConfirmations int32) (string, error) {
-	accountsResponse, err := wallet.GetAccountsRaw(requiredConfirmations)
+func (wallet *Wallet) GetAccounts() (string, error) {
+	accountsResponse, err := wallet.GetAccountsRaw()
 	if err != nil {
 		return "", nil
 	}
@@ -19,14 +19,14 @@ func (wallet *Wallet) GetAccounts(requiredConfirmations int32) (string, error) {
 	return string(result), nil
 }
 
-func (wallet *Wallet) GetAccountsRaw(requiredConfirmations int32) (*Accounts, error) {
+func (wallet *Wallet) GetAccountsRaw() (*Accounts, error) {
 	resp, err := wallet.internal.Accounts(wallet.shutdownContext())
 	if err != nil {
 		return nil, err
 	}
 	accounts := make([]*Account, len(resp.Accounts))
 	for i, account := range resp.Accounts {
-		balance, err := wallet.GetAccountBalance(int32(account.AccountNumber), requiredConfirmations)
+		balance, err := wallet.GetAccountBalance(int32(account.AccountNumber))
 		if err != nil {
 			return nil, err
 		}
@@ -51,8 +51,8 @@ func (wallet *Wallet) GetAccountsRaw(requiredConfirmations int32) (*Accounts, er
 	}, nil
 }
 
-func (wallet *Wallet) AccountsIterator(requiredConfirmations int32) (*AccountsIterator, error) {
-	accounts, err := wallet.GetAccountsRaw(requiredConfirmations)
+func (wallet *Wallet) AccountsIterator() (*AccountsIterator, error) {
+	accounts, err := wallet.GetAccountsRaw()
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +77,13 @@ func (accountsInterator *AccountsIterator) Reset() {
 	accountsInterator.currentIndex = 0
 }
 
-func (wallet *Wallet) GetAccount(accountNumber int32, requiredConfirmations int32) (*Account, error) {
+func (wallet *Wallet) GetAccount(accountNumber int32) (*Account, error) {
 	props, err := wallet.internal.AccountProperties(wallet.shutdownContext(), uint32(accountNumber))
 	if err != nil {
 		return nil, err
 	}
 
-	balance, err := wallet.GetAccountBalance(accountNumber, requiredConfirmations)
+	balance, err := wallet.GetAccountBalance(accountNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +102,8 @@ func (wallet *Wallet) GetAccount(accountNumber int32, requiredConfirmations int3
 	return account, nil
 }
 
-func (wallet *Wallet) GetAccountBalance(accountNumber int32, requiredConfirmations int32) (*Balance, error) {
-	balance, err := wallet.internal.CalculateAccountBalance(wallet.shutdownContext(), uint32(accountNumber), requiredConfirmations)
+func (wallet *Wallet) GetAccountBalance(accountNumber int32) (*Balance, error) {
+	balance, err := wallet.internal.CalculateAccountBalance(wallet.shutdownContext(), uint32(accountNumber), wallet.RequiredConfirmations())
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +119,8 @@ func (wallet *Wallet) GetAccountBalance(accountNumber int32, requiredConfirmatio
 	}, nil
 }
 
-func (wallet *Wallet) SpendableForAccount(account int32, requiredConfirmations int32) (int64, error) {
-	bals, err := wallet.internal.CalculateAccountBalance(wallet.shutdownContext(), uint32(account), requiredConfirmations)
+func (wallet *Wallet) SpendableForAccount(account int32) (int64, error) {
+	bals, err := wallet.internal.CalculateAccountBalance(wallet.shutdownContext(), uint32(account), wallet.RequiredConfirmations())
 	if err != nil {
 		log.Error(err)
 		return 0, translateError(err)

--- a/multiwallet_config.go
+++ b/multiwallet_config.go
@@ -33,7 +33,7 @@ const (
 )
 
 type configSaveFn = func(key string, value interface{}) error
-type configReadFn = func(key string, valueOut interface{}) error
+type configReadFn = func(multiwallet bool, key string, valueOut interface{}) error
 
 func (mw *MultiWallet) walletConfigSetFn(walletID int) configSaveFn {
 	return func(key string, value interface{}) error {
@@ -43,9 +43,11 @@ func (mw *MultiWallet) walletConfigSetFn(walletID int) configSaveFn {
 }
 
 func (mw *MultiWallet) walletConfigReadFn(walletID int) configReadFn {
-	return func(key string, valueOut interface{}) error {
-		walletUniqueKey := WalletUniqueConfigKey(walletID, key)
-		return mw.db.Get(userConfigBucketName, walletUniqueKey, valueOut)
+	return func(multiwallet bool, key string, valueOut interface{}) error {
+		if !multiwallet {
+			key = WalletUniqueConfigKey(walletID, key)
+		}
+		return mw.db.Get(userConfigBucketName, key, valueOut)
 	}
 }
 

--- a/txauthor.go
+++ b/txauthor.go
@@ -16,16 +16,16 @@ import (
 )
 
 type TxAuthor struct {
-	sourceWallet          *Wallet
-	sourceAccountNumber   uint32
-	destinations          []TransactionDestination
+	sourceWallet        *Wallet
+	sourceAccountNumber uint32
+	destinations        []TransactionDestination
 }
 
 func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber int32) *TxAuthor {
 	return &TxAuthor{
-		sourceWallet:          sourceWallet,
-		sourceAccountNumber:   uint32(sourceAccountNumber),
-		destinations:          make([]TransactionDestination, 0),
+		sourceWallet:        sourceWallet,
+		sourceAccountNumber: uint32(sourceAccountNumber),
+		destinations:        make([]TransactionDestination, 0),
 	}
 }
 

--- a/txauthor.go
+++ b/txauthor.go
@@ -19,7 +19,6 @@ type TxAuthor struct {
 	sourceWallet          *Wallet
 	sourceAccountNumber   uint32
 	destinations          []TransactionDestination
-	requiredConfirmations int32
 }
 
 func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber int32) *TxAuthor {
@@ -27,7 +26,6 @@ func (mw *MultiWallet) NewUnsignedTx(sourceWallet *Wallet, sourceAccountNumber i
 		sourceWallet:          sourceWallet,
 		sourceAccountNumber:   uint32(sourceAccountNumber),
 		destinations:          make([]TransactionDestination, 0),
-		requiredConfirmations: mw.RequiredConfirmations(),
 	}
 }
 
@@ -93,7 +91,7 @@ func (tx *TxAuthor) EstimateMaxSendAmount() (*Amount, error) {
 		return nil, err
 	}
 
-	spendableAccountBalance, err := tx.sourceWallet.SpendableForAccount(int32(tx.sourceAccountNumber), tx.requiredConfirmations)
+	spendableAccountBalance, err := tx.sourceWallet.SpendableForAccount(int32(tx.sourceAccountNumber))
 	if err != nil {
 		return nil, err
 	}
@@ -244,6 +242,7 @@ func (tx *TxAuthor) constructTransaction() (*txauthor.AuthoredTx, error) {
 		outputs = append(outputs, output)
 	}
 
+	requiredConfirmations := tx.sourceWallet.RequiredConfirmations()
 	return tx.sourceWallet.internal.NewUnsignedTransaction(ctx, outputs, txrules.DefaultRelayFeePerKb, tx.sourceAccountNumber,
-		tx.requiredConfirmations, outputSelectionAlgorithm, changeSource)
+		requiredConfirmations, outputSelectionAlgorithm, changeSource)
 }

--- a/utils.go
+++ b/utils.go
@@ -50,6 +50,15 @@ func (mw *MultiWallet) RequiredConfirmations() int32 {
 	return DefaultRequiredConfirmations
 }
 
+func (wallet *Wallet) RequiredConfirmations() int32 {
+	var spendUnconfirmed bool
+	wallet.readUserConfigValue(true, SpendUnconfirmedConfigKey, &spendUnconfirmed)
+	if spendUnconfirmed {
+		return 0
+	}
+	return DefaultRequiredConfirmations
+}
+
 func (mw *MultiWallet) listenForShutdown() {
 
 	mw.cancelFuncs = make([]context.CancelFunc, 0)

--- a/utils.go
+++ b/utils.go
@@ -42,6 +42,14 @@ const (
 	DefaultRequiredConfirmations = 2
 )
 
+func (mw *MultiWallet) RequiredConfirmations() int32 {
+	spendUnconfirmed := mw.ReadBoolConfigValueForKey(SpendUnconfirmedConfigKey, false)
+	if spendUnconfirmed {
+		return 0
+	}
+	return DefaultRequiredConfirmations
+}
+
 func (mw *MultiWallet) listenForShutdown() {
 
 	mw.cancelFuncs = make([]context.CancelFunc, 0)

--- a/wallet_config.go
+++ b/wallet_config.go
@@ -23,7 +23,7 @@ func (wallet *Wallet) ReadUserConfigValue(key string, valueOut interface{}) erro
 		return errors.New(ErrFailedPrecondition)
 	}
 
-	err := wallet.readUserConfigValue(key, valueOut)
+	err := wallet.readUserConfigValue(false, key, valueOut)
 	if err != nil && err != storm.ErrNotFound {
 		log.Errorf("error reading config value for key: %s, error: %v", key, err)
 	}


### PR DESCRIPTION
Change from `wallet.NewUnsignedTx` to `multiwallet.NewUnsignedTx` is done to enable the `NewUnsignedTx` method access the user-configured `SpendUnconfirmedFunds` setting.

Also enable access to the `SpendUnconfirmedFunds` setting from wallet methods and remove `requiredConfirmations` parameters from wallet methods.