### PR TITLE
renamed finger print key to biometric key

### DIFF
--- a/multiwallet_config.go
+++ b/multiwallet_config.go
@@ -14,7 +14,7 @@ const (
 
 	IsStartupSecuritySetConfigKey = "startup_security_set"
 	StartupSecurityTypeConfigKey  = "startup_security_type"
-	UseFingerprintConfigKey       = "use_fingerprint"
+	UseBiometricConfigKey         = "use_biometric"
 
 	IncomingTxNotificationsConfigKey = "tx_notification_enabled"
 	BeepNewBlocksConfigKey           = "beep_new_blocks"


### PR DESCRIPTION
IOS uses both Touch ID and face ID so it is appropriate we name the config key to "UseBiometricConfigKey".
required by https://github.com/raedahgroup/dcrios/pull/613