### PR TITLE
Fix recurrent unlock wallet bug

### DIFF
--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -74,14 +74,9 @@ func (mw *MultiWallet) markWalletAsDiscoveredAccounts(walletID int) error {
 		return errors.New(ErrNotExist)
 	}
 
-	err := mw.db.One("ID", walletID, wallet)
-	if err != nil {
-		return err
-	}
-
 	log.Infof("Set discovered accounts = true for wallet %d", wallet.ID)
 	wallet.HasDiscoveredAccounts = true
-	err = mw.db.Save(wallet)
+	err := mw.db.Save(wallet)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes recurrent unlock wallet bug by removing unnecessary fetch of wallet from database and mark wallet as discovered account in synced function. `HasDiscoveredAccounts` was saved only when address discovery ended and wallets that are already synced did not do address discovery so in the case of an error in saving `HasDiscoveredAccounts`, the wallets would need to discover addresses.