### PR TITLE
SPV: send fetch header progress notification for only best block

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1255,14 +1255,13 @@ func (s *Syncer) getHeaders(ctx context.Context, rp *p2p.RemotePeer) error {
 			if len(bestChain) == 1 {
 				log.Infof("[%d] Connected block %v, height %d", walletID, tip.Hash, tip.Header.Height)
 			} else {
+				s.fetchHeadersProgress(headers[len(headers)-1])
 				log.Infof("[%d] Connected %d blocks, new tip %v, height %d, date %v",
 					walletID, len(bestChain), tip.Hash, tip.Header.Height, tip.Header.Timestamp)
 			}
 
 			s.sidechainMu.Unlock()
 		}
-
-		s.fetchHeadersProgress(headers[len(headers)-1])
 
 		// Generate new locators
 		s.locatorMu.Lock()


### PR DESCRIPTION
This PR fixed the issue of headers getting fetched out of order by sending fetch header progress notification for only best block.
closes #126 