### PR TITLE
Register transaction notification after completing sync

### DIFF
--- a/multiwallet.go
+++ b/multiwallet.go
@@ -236,8 +236,6 @@ func (mw *MultiWallet) OpenWallets(startupPassphrase []byte) error {
 		if err != nil {
 			return err
 		}
-
-		go mw.listenForTransactions(wallet.ID)
 	}
 
 	return nil
@@ -434,7 +432,6 @@ func (mw *MultiWallet) saveNewWallet(wallet *Wallet, setupWallet func() error) (
 	}
 
 	mw.wallets[wallet.ID] = wallet
-	go mw.listenForTransactions(wallet.ID)
 
 	return wallet, nil
 }

--- a/syncnotification.go
+++ b/syncnotification.go
@@ -529,6 +529,8 @@ func (mw *MultiWallet) synced(walletID int, synced bool) {
 	wallet := mw.wallets[walletID]
 	wallet.synced = synced
 	wallet.syncing = false
+	mw.listenForTransactions(wallet.ID)
+
 	if !wallet.internal.Locked() {
 		wallet.LockWallet() // lock wallet if previously unlocked to perform account discovery.
 		err := mw.markWalletAsDiscoveredAccounts(walletID)


### PR DESCRIPTION
This fixes a bug that causes the app's UI to lag when fetching headers
Closes #133 