### PR TITLE
Fix seed encryption errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrLoggerAlreadyRegistered      = "logger_already_registered"
 	ErrLogRotatorAlreadyInitialized = "log_rotator_already_initialized"
 	ErrAddressDiscoveryNotDone      = "address_discovery_not_done"
+	ErrChangingPassphrase           = "err_changing_passphrase"
+	ErrSavingWallet                 = "err_saving_wallet"
 )
 
 // todo, should update this method to translate more error kinds.

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -606,13 +606,8 @@ func (mw *MultiWallet) ChangePrivatePassphraseForWallet(walletID int, oldPrivate
 		return errors.New(ErrInvalid)
 	}
 
-	err := wallet.changePrivatePassphrase(oldPrivatePassphrase, newPrivatePassphrase)
-	if err != nil {
-		return translateError(err)
-	}
-
 	if wallet.EncryptedSeed != nil {
-		decryptedSeed, err := decryptWalletSeed(newPrivatePassphrase, wallet.EncryptedSeed)
+		decryptedSeed, err := decryptWalletSeed(oldPrivatePassphrase, wallet.EncryptedSeed)
 		if err != nil {
 			return err
 		}
@@ -623,6 +618,11 @@ func (mw *MultiWallet) ChangePrivatePassphraseForWallet(walletID int, oldPrivate
 		}
 
 		wallet.EncryptedSeed = encrytedSeed
+	}
+
+	err := wallet.changePrivatePassphrase(oldPrivatePassphrase, newPrivatePassphrase)
+	if err != nil {
+		return translateError(err)
 	}
 
 	wallet.PrivatePassphraseType = privatePassphraseType

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -522,7 +522,7 @@ func (mw *MultiWallet) VerifySeedForWallet(walletID int, seedMnemonic string, pr
 		return true, translateError(mw.db.Save(wallet))
 	}
 
-	return false, errors.New(ErrInvalidPassphrase)
+	return false, errors.New(ErrInvalid)
 }
 
 // NumWalletsNeedingSeedBackup returns the number of opened wallets whose seed haven't been verified.
@@ -606,18 +606,17 @@ func (mw *MultiWallet) ChangePrivatePassphraseForWallet(walletID int, oldPrivate
 		return errors.New(ErrInvalid)
 	}
 
-	if wallet.EncryptedSeed != nil {
-		decryptedSeed, err := decryptWalletSeed(oldPrivatePassphrase, wallet.EncryptedSeed)
+	encryptedSeed := wallet.EncryptedSeed
+	if encryptedSeed != nil {
+		decryptedSeed, err := decryptWalletSeed(oldPrivatePassphrase, encryptedSeed)
 		if err != nil {
 			return err
 		}
 
-		encrytedSeed, err := encryptWalletSeed(newPrivatePassphrase, decryptedSeed)
+		encryptedSeed, err = encryptWalletSeed(newPrivatePassphrase, decryptedSeed)
 		if err != nil {
 			return err
 		}
-
-		wallet.EncryptedSeed = encrytedSeed
 	}
 
 	err := wallet.changePrivatePassphrase(oldPrivatePassphrase, newPrivatePassphrase)
@@ -625,6 +624,7 @@ func (mw *MultiWallet) ChangePrivatePassphraseForWallet(walletID int, oldPrivate
 		return translateError(err)
 	}
 
+	wallet.EncryptedSeed = encryptedSeed
 	wallet.PrivatePassphraseType = privatePassphraseType
 	return mw.db.Save(wallet)
 }

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -418,7 +418,12 @@ func (mw *MultiWallet) saveNewWallet(wallet *Wallet, setupWallet func() error) (
 		if err != nil {
 			return err
 		} else if dirExists {
-			os.RemoveAll(walletDataDir)
+			newDirName, err := backupFile(walletDataDir)
+			if err != nil {
+				return err
+			}
+
+			log.Info("Undocumented file at %s moved to %s", walletDataDir, newDirName)
 		}
 
 		os.MkdirAll(walletDataDir, os.ModePerm) // create wallet dir

--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -117,11 +117,6 @@ func (mw *MultiWallet) RootDirFileSizeInBytes() (int64, error) {
 
 // naclLoadFromPass derives a nacl.Key from pass using scrypt.Key.
 func naclLoadFromPass(pass []byte) (nacl.Key, error) {
-	defer func() {
-		for i := range pass {
-			pass[i] = 0
-		}
-	}()
 
 	const N, r, p = 1 << 15, 8, 1
 
@@ -150,7 +145,7 @@ func decryptWalletSeed(pass []byte, encryptedSeed []byte) (string, error) {
 
 	decryptedSeed, err := secretbox.EasyOpen(encryptedSeed, key)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("decryptWalletSeed secretbox.EasyOpen error: %v", err)
 		return "", errors.New(ErrInvalidPassphrase)
 	}
 

--- a/multiwallet_utils.go
+++ b/multiwallet_utils.go
@@ -150,7 +150,8 @@ func decryptWalletSeed(pass []byte, encryptedSeed []byte) (string, error) {
 
 	decryptedSeed, err := secretbox.EasyOpen(encryptedSeed, key)
 	if err != nil {
-		return "", err
+		log.Error(err)
+		return "", errors.New(ErrInvalidPassphrase)
 	}
 
 	return string(decryptedSeed), nil

--- a/multiwallet_utils_test.go
+++ b/multiwallet_utils_test.go
@@ -21,7 +21,6 @@ var _ = Describe("MultiwalletUtils", func() {
 		Context("encryptWalletSeed and decryptWalletSeed", func() {
 			It("encrypts and decrypts the wallet seed properly", func() {
 				pass := genPass()
-				pass2 := bytes.Repeat(pass, 1) // Required because the functions clear the pass memory after use
 				fakePass := genPass()
 				for bytes.Equal(pass, fakePass) {
 					fakePass = genPass()
@@ -39,7 +38,7 @@ var _ = Describe("MultiwalletUtils", func() {
 				Expect(err).ToNot(BeNil())
 
 				By("Decrypting the encrypted seed using the correct password")
-				decrypted, err := decryptWalletSeed(pass2, encrypted)
+				decrypted, err := decryptWalletSeed(pass, encrypted)
 				Expect(err).To(BeNil())
 
 				By("Comparing the decrypted and original seeds")

--- a/utils.go
+++ b/utils.go
@@ -260,6 +260,29 @@ func moveFile(sourcePath, destinationPath string) error {
 	return nil
 }
 
+func backupFile(fileName string) (newName string, err error) {
+	var backup func(f string) error
+	backup = func(f string) error {
+		newName = f + ".bak"
+		exists, err := fileExists(newName)
+		if err != nil {
+			return err
+		} else if exists {
+			return backup(newName)
+		}
+
+		err = moveFile(fileName, newName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	err = backup(fileName)
+	return
+}
+
 func initWalletLoader(chainParams *chaincfg.Params, walletDataDir, walletDbDriver string) *loader.Loader {
 	defaultFeePerKb := txrules.DefaultRelayFeePerKb.ToCoin()
 	stakeOptions := &loader.StakeOptions{

--- a/utils.go
+++ b/utils.go
@@ -261,26 +261,20 @@ func moveFile(sourcePath, destinationPath string) error {
 }
 
 func backupFile(fileName string) (newName string, err error) {
-	var backup func(f string) error
-	backup = func(f string) error {
-		newName = f + ".bak"
-		exists, err := fileExists(newName)
-		if err != nil {
-			return err
-		} else if exists {
-			return backup(newName)
-		}
-
-		err = moveFile(fileName, newName)
-		if err != nil {
-			return err
-		}
-
-		return nil
+	newName = fileName + ".bak"
+	exists, err := fileExists(newName)
+	if err != nil {
+		return "", err
+	} else if exists {
+		return backupFile(newName)
 	}
 
-	err = backup(fileName)
-	return
+	err = moveFile(fileName, newName)
+	if err != nil {
+		return "", err
+	}
+
+	return newName, nil
 }
 
 func initWalletLoader(chainParams *chaincfg.Params, walletDataDir, walletDbDriver string) *loader.Loader {

--- a/wallet.go
+++ b/wallet.go
@@ -272,5 +272,9 @@ func (wallet *Wallet) deleteWallet(privatePassphrase []byte) error {
 
 // DecryptSeed decrypts wallet.EncryptedSeed using privatePassphrase
 func (wallet *Wallet) DecryptSeed(privatePassphrase []byte) (string, error) {
+	if wallet.EncryptedSeed == nil {
+		return "", errors.New(ErrInvalid)
+	}
+
 	return decryptWalletSeed(privatePassphrase, wallet.EncryptedSeed)
 }


### PR DESCRIPTION
Addresses an issue where verify seed function returns ErrInvalid for an incorrect passphrase and also fixes a bug where the seed of an already backed up wallet is attempted to be re-encrypted meanwhile the encrypted seed is empty and that throws an uncaught error.